### PR TITLE
Fix the compilation on Linux/OS X with gcc and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC_FILES
     src/common/Common.cpp
     src/common/Directory.cpp
     src/common/FileStream.cpp
+    src/common/HashToPtr.cpp
     src/common/ListFile.cpp
     src/jenkins/lookup3.c
     src/CascBuildCfg.cpp

--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -33,6 +33,12 @@
 // For HashStringJenkins
 #include "jenkins/lookup.h"
 
+#ifdef __GNUC__
+#include <stddef.h>
+#undef FIELD_OFFSET
+#define FIELD_OFFSET(t,f) offsetof(t,f)
+#endif
+
 //-----------------------------------------------------------------------------
 // CascLib private defines
 

--- a/src/common/Directory.cpp
+++ b/src/common/Directory.cpp
@@ -12,6 +12,12 @@
 #include "../CascLib.h"
 #include "../CascCommon.h"
 
+#ifndef PLATFORM_WINDOWS
+#include <sys/types.h>
+#include <dirent.h>
+#endif
+
+
 //-----------------------------------------------------------------------------
 // Public functions
 


### PR DESCRIPTION
Hello

Here are a few changes I add to do to compile the library on my machines.

Tested on:
- Ubuntu with _gcc 4.7.2_ and _Ubuntu clang version 3.0_
- OS X 10.9 with _Apple LLVM version 5.0 (clang-500.2.79)_
