### PR TITLE
fix: include stddef.h on osx: contains offsetof() macro

### DIFF
--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -66,6 +66,7 @@
   #include <stdlib.h>
   #include <dirent.h>
   #include <errno.h>
+  #include <stddef.h>
 
   // Support for PowerPC on Max OS X
   #if (__ppc__ == 1) || (__POWERPC__ == 1) || (_ARCH_PPC == 1)


### PR DESCRIPTION
would not compile on yosemite with clang-600.0.54.
