### PR TITLE
Expose error functions

### DIFF
--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -32,8 +32,18 @@ extern unsigned char IntToHexChar[];
 // GetLastError/SetLastError support for non-Windows platform
 
 #ifndef PLATFORM_WINDOWS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int GetLastError();
 void SetLastError(int nError);
+
+#ifdef __cplusplus
+}   // extern "C"
+#endif
+
 #endif  // PLATFORM_WINDOWS
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This ensures `GetLastError` and `SetLastError` have C-linkage, in line with [their declaration in StormLib](https://github.com/ladislav-zezula/StormLib/blob/58166d6ba7fa1bc76b2569b9f03d9e4a1642e416/src/StormLib.h#L1072-L1080).

I'm not sure if anything else in that file should be externed in addition.