### PR TITLE
Prevent Casc handle leak when CascOpenFile returns false but handler was already created

### DIFF
--- a/src/CascOpenFile.cpp
+++ b/src/CascOpenFile.cpp
@@ -242,7 +242,10 @@ bool WINAPI CascOpenFile(HANDLE hStorage, const char * szFileName, DWORD dwLocal
 #endif
 
     if(nError != ERROR_SUCCESS)
+    {
+        if(IsValidFileHandle(phFile)) CascCloseFile(phFile);
         SetLastError(nError);
+    }
     return (nError == ERROR_SUCCESS);
 }
 


### PR DESCRIPTION
Not sure if this is the proper way to fix it, but it's an attempt to release memory stored into handler when OpenCascFile is going to return false.