### PR TITLE
Ignore Makefile to prevent git v1.7.0+ "feature"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /CMakeFiles/
 /CMakeCache.txt
 /*.cmake
+/Makefile
 
 # Visual Studio related files
 *.opensdf


### PR DESCRIPTION
Versions 1.7.0 and later of `git` contain an annoying change in the behavior of `git submodule`.
Submodules are now regarded as **dirty** if they have any modified files or untracked files, whereas previously it would only be the case if HEAD in the submodule pointed to the wrong commit.

When building and creating an application using **CascLib** as a `git submodule`, it flags the repo as **dirty** because of the `Makefile`.

This change adds the `Makefile` to `.gitignore` next to the rest of the CMake files.