### PR TITLE
Fixed memory leaks in ParseFile_BuildInfo

### DIFF
--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -580,6 +580,9 @@ static int ParseFile_BuildInfo(TCascStorage * hs, void * pvListFile)
             break;
 
         // Free the blobs
+        FreeCascBlob(&Active);
+        FreeCascBlob(&hs->CdnBuildKey);
+        FreeCascBlob(&hs->CdnConfigKey);
         FreeCascBlob(&CdnHost);
         FreeCascBlob(&CdnPath);
         FreeCascBlob(&TagString);


### PR DESCRIPTION
Happens when there are multiple builds defined in .build.info file and the first one is not active
(failing assertion pbData != NULL in debug mode)