### PR TITLE
Overwatch root file fix

### DIFF
--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -964,7 +964,9 @@ int ParseRootFileLine(const char * szLinePtr, const char * szLineEnd, PQUERY_KEY
     // Skip the MD5
     szLinePtr += MD5_STRING_SIZE+1;
 
-    // Skip the chunk ID
+    // Skip the chunk ID, priority and MR priority
+    szLinePtr = SkipInfoVariable(szLinePtr, szLineEnd);
+    szLinePtr = SkipInfoVariable(szLinePtr, szLineEnd);
     szLinePtr = SkipInfoVariable(szLinePtr, szLineEnd);
 
     // Get the archived file name


### PR DESCRIPTION
Lines are like this now

    #MD5|CHUNK_ID|PRIORITY|MPRIORITY|FILENAME|INSTALLPATH
    993CA6773668FC9E04C167BB9A6CA8FF|0|0|255|PtrClient/Overwatch.exe|Overwatch.exe