### PR TITLE
Support for longer .build.info lines

### DIFF
--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -523,7 +523,7 @@ static int ParseFile_BuildInfo(TCascStorage * hs, void * pvListFile)
     QUERY_KEY CdnHost = {NULL, 0};
     QUERY_KEY CdnPath = {NULL, 0};
     char szOneLine1[0x200];
-    char szOneLine2[0x200];
+    char szOneLine2[0x400];
     size_t nLength1;
     size_t nLength2;
     int nError = ERROR_BAD_FORMAT;


### PR DESCRIPTION
The second line of my .build.info for Diablo 3 is 636 characters long, after installing all language packs.