### PR TITLE
Increase line length for .build.info parsing

### DIFF
--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -523,7 +523,7 @@ static int ParseFile_BuildInfo(TCascStorage * hs, void * pvListFile)
     QUERY_KEY CdnHost = {NULL, 0};
     QUERY_KEY CdnPath = {NULL, 0};
     char szOneLine1[0x200];
-    char szOneLine2[0x400];
+    char szOneLine2[0x800];
     size_t nLength1;
     size_t nLength2;
     int nError = ERROR_BAD_FORMAT;


### PR DESCRIPTION
`eu|1|46860318595610e57bc41142ee83c7d3|62f2b9a23266bc35767fea353c5da4f6|49ee4cde87b45796b810e32c0cf9388c|21440|/tpr/wow|blzddist1-a.akamaihd.net blzddist2-a.akamaihd.net|Windows x86_32 x86_64 EU?deDE speech?:Windows x86_32 x86_64 EU? deDE text?:Windows x86_32 x86_64 EU? enUS speech?:Windows x86_32 x86_64 EU? enUS text?:Windows x86_32 x86_64 EU? esES speech?:Windows x86_32 x86_64 EU? esES text?:Windows x86_32 x86_64 EU? esMX speech?:Windows x86_32 x86_64 EU? esMX text?:Windows x86_32 x86_64 EU? frFR speech?:Windows x86_32 x86_64 EU? frFR text?:Windows x86_32 x86_64 EU? itIT speech?:Windows x86_32 x86_64 EU? itIT text?:Windows x86_32 x86_64 EU? koKR speech?:Windows x86_32 x86_64 EU? koKR text?:Windows x86_32 x86_64 EU? ptBR speech?:Windows x86_32 x86_64 EU? ptBR text?:Windows x86_32 x86_64 EU? ruRU speech?:Windows x86_32 x86_64 EU? ruRU text?:Windows x86_32 x86_64 EU? zhCN speech?:Windows x86_32 x86_64 EU? zhCN text?:Windows x86_32 x86_64 EU? zhTW speech?:Windows x86_32 x86_64 EU? zhTW text?||2016-07-23T01:19:52Z|7.0.3.22293`

This is wow client with all locales installed, current length = 0x40D