### PR TITLE
Fix leaked handle in case calling fstat64 fails when trying to open file

### DIFF
--- a/src/common/FileStream.cpp
+++ b/src/common/FileStream.cpp
@@ -134,6 +134,7 @@ static bool BaseFile_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD
         if(fstat64(handle, &fileinfo) == -1)
         {
             SetLastError(errno);
+            close(handle);
             return false;
         }
 


### PR DESCRIPTION
If calling fstat64 in BaseFile_Open fails then opened file handle is not assigned to `pStream->Base.File.hFile` field, causing the handle to not be closed in BaseFile_Close leaking it.