### PR TITLE
More static analysis fixes

### DIFF
--- a/src/common/FileStream.cpp
+++ b/src/common/FileStream.cpp
@@ -193,7 +193,11 @@ static bool BaseFile_Read(
         // we have to update the file position
         if(ByteOffset != pStream->Base.File.FilePos)
         {
-            lseek64((intptr_t)pStream->Base.File.hFile, (off64_t)(ByteOffset), SEEK_SET);
+            if(lseek64((intptr_t)pStream->Base.File.hFile, (off64_t)(ByteOffset), SEEK_SET) == (off64_t)-1)
+            {
+                SetLastError(errno);
+                return false;
+            }
             pStream->Base.File.FilePos = ByteOffset;
         }
 
@@ -264,7 +268,11 @@ static bool BaseFile_Write(TFileStream * pStream, ULONGLONG * pByteOffset, const
         // we have to update the file position
         if(ByteOffset != pStream->Base.File.FilePos)
         {
-            lseek64((intptr_t)pStream->Base.File.hFile, (off64_t)(ByteOffset), SEEK_SET);
+            if(lseek64((intptr_t)pStream->Base.File.hFile, (off64_t)(ByteOffset), SEEK_SET) == (off64_t)-1)
+            {
+                SetLastError(errno);
+                return false;
+            }
             pStream->Base.File.FilePos = ByteOffset;
         }
 

--- a/src/common/ListFile.cpp
+++ b/src/common/ListFile.cpp
@@ -324,8 +324,11 @@ PLISTFILE_MAP ListFile_CreateMap(const TCHAR * szListFile)
                         break;
                 }
 
-                // Finish the listfile map
-                pListMap = ListMap_Finish(pListMap);
+                if(pListMap == NULL)
+                {
+                    // Finish the listfile map
+                    pListMap = ListMap_Finish(pListMap);
+                }
 
                 // Free the listfile
                 ListFile_Free(pvListFile);

--- a/src/common/Map.cpp
+++ b/src/common/Map.cpp
@@ -130,9 +130,11 @@ size_t Map_EnumObjects(PCASC_MAP pMap, void **ppvArray)
                 ppvArray[nIndex++] = pMap->HashTable[i];
             }
         }
+
+        return pMap->ItemCount;
     }
 
-    return pMap->ItemCount;
+    return 0;
 }
 
 void * Map_FindObject(PCASC_MAP pMap, void * pvKey, PDWORD PtrIndex)


### PR DESCRIPTION
Handle lseek64 failure
Fix possible null dereference

Found when running coverity on TrinityCore