### PR TITLE
Always call SetLastError in public API functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@
 *.sdf
 *.suo
 *.vcxproj.user
+*.db
+*.opendb
 
 # KDevelop related files
 *.kdev4
@@ -40,3 +42,4 @@
 /casc.dir/
 /Win32/
 /Debug/
+bin/

--- a/src/CascFindFile.cpp
+++ b/src/CascFindFile.cpp
@@ -290,6 +290,7 @@ HANDLE WINAPI CascFindFirstFile(
         pSearch = NULL;
     }
 
+    SetLastError(nError);
     return (HANDLE)pSearch;
 }
 
@@ -307,7 +308,14 @@ bool WINAPI CascFindNextFile(
     }
 
     // Perform search
-    return DoStorageSearch(pSearch, pFindData);
+    if(!DoStorageSearch(pSearch, pFindData))
+    {
+        SetLastError(ERROR_NO_MORE_FILES);
+        return false;
+    }
+
+    SetLastError(ERROR_SUCCESS);
+    return true;
 }
 
 bool WINAPI CascFindClose(HANDLE hFind)
@@ -322,5 +330,6 @@ bool WINAPI CascFindClose(HANDLE hFind)
     }
 
     FreeSearchHandle(pSearch);
+    SetLastError(ERROR_SUCCESS);
     return true;
 }

--- a/src/CascOpenFile.cpp
+++ b/src/CascOpenFile.cpp
@@ -102,8 +102,7 @@ static bool OpenFileByIndexKey(TCascStorage * hs, PQUERY_KEY pIndexKey, DWORD dw
     }
 #endif
 
-    if(nError != ERROR_SUCCESS)
-        SetLastError(nError);
+    SetLastError(nError);
     return (nError == ERROR_SUCCESS);
 }
 
@@ -265,8 +264,7 @@ bool WINAPI CascOpenFile(HANDLE hStorage, const char * szFileName, DWORD dwLocal
 //  }
 #endif
 
-    if(nError != ERROR_SUCCESS)
-        SetLastError(nError);
+    SetLastError(nError);
     return (nError == ERROR_SUCCESS);
 }
 
@@ -313,6 +311,7 @@ bool WINAPI CascCloseFile(HANDLE hFile)
         // Free the structure itself
         hf->szClassName = NULL;
         CASC_FREE(hf);
+        SetLastError(ERROR_SUCCESS);
         return true;
     }
 

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -1079,10 +1079,10 @@ bool WINAPI CascOpenStorage(const TCHAR * szDataPath, DWORD dwLocaleMask, HANDLE
     if(nError != ERROR_SUCCESS)
     {
         hs = FreeCascStorage(hs);
-        SetLastError(nError);
     }
 
     *phStorage = (HANDLE)hs;
+    SetLastError(nError);
     return (nError == ERROR_SUCCESS);
 }
 
@@ -1141,6 +1141,7 @@ bool WINAPI CascGetStorageInfo(
 
     // Give the number of files
     *(PDWORD)pvStorageInfo = dwInfoValue;
+    SetLastError(ERROR_SUCCESS);
     return true;
 }
 
@@ -1160,11 +1161,13 @@ bool WINAPI CascCloseStorage(HANDLE hStorage)
     if(hs->dwRefCount == 1)
     {
         FreeCascStorage(hs);
+        SetLastError(ERROR_SUCCESS);
         return true;
     }
 
     // Just decrement number of references
     hs->dwRefCount--;
+    SetLastError(ERROR_SUCCESS);
     return true;
 }
 

--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -28,6 +28,9 @@
   #define _CRT_SECURE_NO_DEPRECATE
   #define _CRT_NON_CONFORMING_SWPRINTFS
   #endif
+  #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+  #endif
 
   #include <tchar.h>
   #include <assert.h>

--- a/src/CascReadFile.cpp
+++ b/src/CascReadFile.cpp
@@ -386,6 +386,8 @@ DWORD WINAPI CascGetFileSize(HANDLE hFile, PDWORD pdwFileSizeHigh)
         return CASC_INVALID_SIZE;
     }
 
+    SetLastError(ERROR_SUCCESS);
+
     // Give the file size to the caller
     if(pdwFileSizeHigh != NULL)
         *pdwFileSizeHigh = 0;
@@ -449,6 +451,8 @@ DWORD WINAPI CascSetFilePointer(HANDLE hFile, LONG lFilePos, LONG * plFilePosHig
 
     // Change the file position
     hf->FilePointer = (DWORD)FilePosition;
+
+    SetLastError(ERROR_SUCCESS);
 
     // Return the new file position
     if(plFilePosHigh != NULL)
@@ -613,8 +617,7 @@ bool WINAPI CascReadFile(HANDLE hFile, void * pvBuffer, DWORD dwBytesToRead, PDW
         hf->FilePointer = dwFilePointer;
     }
 
-    if(nError != ERROR_SUCCESS)
-        SetLastError(nError);
+    SetLastError(nError);
     return (nError == ERROR_SUCCESS);
 }
 

--- a/src/CascRootFile_Diablo3.cpp
+++ b/src/CascRootFile_Diablo3.cpp
@@ -337,7 +337,7 @@ static size_t CreateShortName(
         }
         else
         {
-			strcpy(szBuffer + nLength, "unk");
+            strcpy(szBuffer + nLength, "unk");
             nLength += 3;
         }
     }
@@ -994,8 +994,9 @@ static LPBYTE D3Handler_GetKey(TRootHandler_Diablo3 * pRootHandler, const char *
 
 static DWORD D3Handler_GetFileId(TRootHandler_Diablo3 * /* pRootHandler */, const char * /* szFileName */)
 {
-  // Not implemented for D3
-  return 0;
+    // Not implemented for D3
+    SetLastError(ERROR_SUCCESS);
+    return 0;
 }
 
 static void D3Handler_Close(TRootHandler_Diablo3 * pRootHandler)

--- a/src/CascRootFile_Mndx.cpp
+++ b/src/CascRootFile_Mndx.cpp
@@ -3087,8 +3087,9 @@ static void MndxHandler_EndSearch(TRootHandler_MNDX * /* pRootHandler */, TCascS
 
 static DWORD MndxHandler_GetFileId(TRootHandler_MNDX * /* pRootHandler */, const char * /* szFileName */)
 {
-  // Not implemented for HOTS
-  return 0;
+    // Not implemented for HOTS
+    SetLastError(ERROR_SUCCESS);
+    return 0;
 }
 
 static LPBYTE MndxHandler_GetKey(TRootHandler_MNDX * pRootHandler, const char * szFileName)

--- a/src/CascRootFile_WoW6.cpp
+++ b/src/CascRootFile_WoW6.cpp
@@ -457,7 +457,13 @@ static DWORD WowHandler_GetFileId(TRootHandler_WoW6 * pRootHandler, const char *
 
     // Find by the file name hash
     pFileEntry = FindRootEntry(pRootHandler->pRootMap, szFileName, NULL);
-    return (pFileEntry != NULL) ? pFileEntry->FileDataId : NULL;
+    if(pFileEntry == NULL)
+    {
+        SetLastError(ERROR_FILE_NOT_FOUND);
+        return 0;
+    }
+    SetLastError(ERROR_SUCCESS);
+    return pFileEntry->FileDataId;
 }
 
 static void WowHandler_Close(TRootHandler_WoW6 * pRootHandler)


### PR DESCRIPTION
On platforms other than windows `GetLastError()` is not reset automatically by winapi between Casc* API calls
This leads to unwanted situation where `GetLastError() != ERROR_SUCCESS` but Casc* call returned true