### PR TITLE
Linux closing file descriptor 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@
 *.sdf
 *.suo
 *.vcxproj.user
+*.db
+*.opendb
 
 # KDevelop related files
 *.kdev4
@@ -40,3 +42,4 @@
 /casc.dir/
 /Win32/
 /Debug/
+bin/

--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -28,6 +28,9 @@
   #define _CRT_SECURE_NO_DEPRECATE
   #define _CRT_NON_CONFORMING_SWPRINTFS
   #endif
+  #ifndef WIN32_LEAN_AND_MEAN
+  #define WIN32_LEAN_AND_MEAN
+  #endif
 
   #include <tchar.h>
   #include <assert.h>

--- a/src/common/FileStream.cpp
+++ b/src/common/FileStream.cpp
@@ -74,6 +74,7 @@ static bool BaseFile_Create(TFileStream * pStream)
         handle = open(pStream->szFileName, O_RDWR | O_CREAT | O_TRUNC | O_LARGEFILE, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
         if(handle == -1)
         {
+            pStream->Base.File.hFile = INVALID_HANDLE_VALUE;
             SetLastError(errno);
             return false;
         }
@@ -123,6 +124,7 @@ static bool BaseFile_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD
         intptr_t handle;
 
         // Open the file
+        pStream->Base.File.hFile = INVALID_HANDLE_VALUE;
         handle = open(szFileName, oflag | O_LARGEFILE);
         if(handle == -1)
         {


### PR DESCRIPTION
Fixes closing file descriptor 0 (/dev/tty1 on my system or one of casc storage files on subsequent CascOpenStorage calls) causing file operations to randomly fail when accessing a closed data.xxx file