### PR TITLE
Fix build on Mac/Linux

### DIFF
--- a/src/CascRootFile_Diablo3.cpp
+++ b/src/CascRootFile_Diablo3.cpp
@@ -606,7 +606,7 @@ static void ResolveFullFileNames(
     char szFullName[MAX_PATH+1];
 
     // Keep compiler happy
-    UNREFERENCED_PARAMETER(dwFileIndexes);
+    CASCLIB_UNUSED(dwFileIndexes);
 
     // Parse the entire file table
     for(size_t i = 0; i < pRootHandler->FileTable.ItemCount; i++)

--- a/src/CascRootFile_WoW6.cpp
+++ b/src/CascRootFile_WoW6.cpp
@@ -457,7 +457,7 @@ static DWORD WowHandler_GetFileId(TRootHandler_WoW6 * pRootHandler, const char *
 
     // Find by the file name hash
     pFileEntry = FindRootEntry(pRootHandler->pRootMap, szFileName, NULL);
-    return (pFileEntry != NULL) ? pFileEntry->FileDataId : NULL;
+    return (pFileEntry != NULL) ? pFileEntry->FileDataId : 0;
 }
 
 static void WowHandler_Close(TRootHandler_WoW6 * pRootHandler)

--- a/src/common/RootHandler.cpp
+++ b/src/common/RootHandler.cpp
@@ -81,7 +81,7 @@ DWORD RootHandler_GetFileId(TRootHandler * pRootHandler, const char * szFileName
 {
     // Check if the root structure is valid at all
     if(pRootHandler == NULL)
-        return NULL;
+        return 0;
 
     return pRootHandler->GetFileId(pRootHandler, szFileName);
 }


### PR DESCRIPTION
Currently the lib doesn't compile on Mac/Linux because one .cpp file uses the macro ` UNREFERENCED_PARAMETER` which is only defined on Windows. Fixed by using CASCLIB_UNUSED. Also removed 2 warnings due to casting NULL to DWORD.

The lib now compiles and works correctly (tested on Mac OS X with HOTS).