### PR TITLE
fixed compile errors on casclib_dll on vs2017

### DIFF
--- a/CascLib_vs17_dll.vcxproj
+++ b/CascLib_vs17_dll.vcxproj
@@ -98,7 +98,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)CascLib.dll</OutputFile>
+      <OutputFile>$(OutDir)CascLib_dll.dll</OutputFile>
       <ModuleDefinitionFile>.\src\CascLib.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
@@ -140,7 +140,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <OutputFile>$(OutDir)CascLib.dll</OutputFile>
+      <OutputFile>$(OutDir)CascLib_dll.dll</OutputFile>
       <ModuleDefinitionFile>.\src\CascLib.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
@@ -191,6 +191,7 @@
     <ClCompile Include="src\CascRootFile_Diablo3.cpp" />
     <ClCompile Include="src\CascRootFile_Mndx.cpp" />
     <ClCompile Include="src\CascRootFile_Ovr.cpp" />
+    <ClCompile Include="src\CascRootFile_SC1.cpp" />
     <ClCompile Include="src\CascRootFile_WoW6.cpp" />
     <ClCompile Include="src\common\Common.cpp" />
     <ClCompile Include="src\common\Directory.cpp" />

--- a/src/CascLib.def
+++ b/src/CascLib.def
@@ -4,7 +4,7 @@
 ; ladik@zezula.net
 ;
 
-LIBRARY CascLib.dll
+LIBRARY CascLib_dll.dll
 
 EXPORTS
 


### PR DESCRIPTION
fixed some compile errors for building the .dll file in vs2017