### PR TITLE
Add a way to get available locales from .build.info

### DIFF
--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -151,6 +151,7 @@ typedef enum _CASC_STORAGE_INFO_CLASS
     CascStorageFeatures,
     CascStorageGameInfo,
     CascStorageGameBuild,
+    CascStorageInstalledLocales,
     CascStorageInfoClassMax
 
 } CASC_STORAGE_INFO_CLASS, *PCASC_STORAGE_INFO_CLASS;
@@ -169,7 +170,7 @@ typedef struct _CASC_FIND_DATA
     char * szPlainName;                         // Plain name of the found file
     BYTE   EncodingKey[MD5_HASH_SIZE];          // Encoding key
     DWORD  dwLocaleFlags;                       // Locale flags (WoW only)
-    DWORD  dwFileDataId;                        // File data ID (WoW only) 
+    DWORD  dwFileDataId;                        // File data ID (WoW only)
     DWORD  dwFileSize;                          // Size of the file
 
 } CASC_FIND_DATA, *PCASC_FIND_DATA;

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -1149,6 +1149,10 @@ bool WINAPI CascGetStorageInfo(
             dwInfoValue = hs->dwBuildNumber;
             break;
 
+        case CascStorageInstalledLocales:
+            dwInfoValue = hs->dwDefaultLocale;
+            break;
+
         default:
             SetLastError(ERROR_INVALID_PARAMETER);
             return false;


### PR DESCRIPTION
Expose parsed locale tags from .build.info

Some time ago something changed that CascOpenStorage no longer fails when given unavailable locale, instead it now allows operating on all files which are shared by all locales
This behavior is undesirable in the tool extracting all db2 files as it should either extract everything or nothing. Right now it extracts a partial set of files (these that don't have any localized strings in them) and this change allows me to filter out these locales