### PR TITLE
Non-windows fixes & SC1 search mask support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRC_FILES
     src/CascOpenFile.cpp
     src/CascOpenStorage.cpp
     src/CascReadFile.cpp
+    src/CascRootFile_SC1.cpp
     src/CascRootFile_Diablo3.cpp
     src/CascRootFile_Mndx.cpp
     src/CascRootFile_Ovr.cpp

--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -153,6 +153,7 @@
   typedef LONG         * PLONG;
   typedef DWORD        * PDWORD;
   typedef BYTE         * LPBYTE;
+  typedef char         * LPSTR;
 
   #ifdef PLATFORM_32BIT
     #define _LZMA_UINT32_IS_ULONG

--- a/src/CascRootFile_SC1.cpp
+++ b/src/CascRootFile_SC1.cpp
@@ -86,11 +86,15 @@ static LPBYTE SC1Handler_Search(TRootHandler_SC1 * pRootHandler, TCascSearch * p
     {
         // Retrieve the file item
         pFileEntry = (PCASC_FILE_ENTRY)Array_ItemAt(&pRootHandler->FileTable, pSearch->IndexLevel1);
-        strcpy(pSearch->szFileName, (char *)Array_ItemAt(&pRootHandler->FileNames, pFileEntry->dwFileName));        
         
         // Prepare the pointer to the next search
         pSearch->IndexLevel1++;
-        return pFileEntry->EncodingKey.Value;
+		
+		char *filename = (char *)Array_ItemAt(&pRootHandler->FileNames, pFileEntry->dwFileName);
+		if (CheckWildCard(filename, pSearch->szMask)) {
+			strcpy(pSearch->szFileName, filename);
+			return pFileEntry->EncodingKey.Value;
+		}
     }
 
     // No more entries

--- a/src/CascRootFile_SC1.cpp
+++ b/src/CascRootFile_SC1.cpp
@@ -90,11 +90,11 @@ static LPBYTE SC1Handler_Search(TRootHandler_SC1 * pRootHandler, TCascSearch * p
         // Prepare the pointer to the next search
         pSearch->IndexLevel1++;
 		
-		char *filename = (char *)Array_ItemAt(&pRootHandler->FileNames, pFileEntry->dwFileName);
-		if (CheckWildCard(filename, pSearch->szMask)) {
-			strcpy(pSearch->szFileName, filename);
-			return pFileEntry->EncodingKey.Value;
-		}
+        char *filename = (char *)Array_ItemAt(&pRootHandler->FileNames, pFileEntry->dwFileName);
+        if (CheckWildCard(filename, pSearch->szMask)) {
+            strcpy(pSearch->szFileName, filename);
+            return pFileEntry->EncodingKey.Value;
+        }
     }
 
     // No more entries


### PR DESCRIPTION
- Added CascRootFile_SC1.cpp to CMakeLists.txt
- Added LPSTR definition to CascPort.h
- Added support for search mask to CascRootFile_SC1.cpp