### PR TITLE
Enclose some #define in #ifndef statements

### DIFF
--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -25,11 +25,16 @@
 
   // In MSVC 8.0, there are some functions declared as deprecated.
   #if _MSC_VER >= 1400
-  #define _CRT_SECURE_NO_DEPRECATE
-  #define _CRT_NON_CONFORMING_SWPRINTFS
+    #ifndef _CRT_SECURE_NO_DEPRECATE
+      #define _CRT_SECURE_NO_DEPRECATE
+    #endif
+    #ifndef _CRT_NON_CONFORMING_SWPRINTFS
+      #define _CRT_NON_CONFORMING_SWPRINTFS
+    #endif
   #endif
+
   #ifndef WIN32_LEAN_AND_MEAN
-  #define WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
   #endif
 
   #include <tchar.h>


### PR DESCRIPTION
Using CascLib + WxWidgets in WoW Model Viewer fires me some warnings about _CRT_SECURE_NO_DEPRECATE & _CRT_NON_CONFORMING_SWPRINTFS already defined.
As wxWidgets also define those (as of you, to avoid MSCV8.0 warning), I assume it is better to enclose them in #ifndef statements.