### PR TITLE
fix V773 with PVS-Studio

### DIFF
--- a/src/CascRootFile_Mndx.cpp
+++ b/src/CascRootFile_Mndx.cpp
@@ -2717,13 +2717,17 @@ int TFileNameDatabasePtr::CreateDatabase(LPBYTE pbMarData, DWORD cbMarData)
         return ERROR_NOT_ENOUGH_MEMORY;
 
     nError = ByteStream.SetByteBuffer(pbMarData, cbMarData);
-    if(nError != ERROR_SUCCESS)
-        return nError;
+	if (nError != ERROR_SUCCESS) {
+		delete pDatabase;
+		return nError;
+	}
 
     // HOTS: 1956E11
     nError = pDatabase->LoadFromStream_Exchange(ByteStream);
-    if(nError != ERROR_SUCCESS)
-        return nError;
+	if (nError != ERROR_SUCCESS) {
+		delete pDatabase;
+		return nError;
+	}
 
     pDB = pDatabase;
     return ERROR_SUCCESS;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'pDatabase' pointer. A memory leak is possible.

(https://github.com/ladislav-zezula/CascLib/blob/master/src/CascRootFile_Mndx.cpp#L2721)

