### PR TITLE
Fix include guards and macro definitions

### DIFF
--- a/src/CascCommon.cpp
+++ b/src/CascCommon.cpp
@@ -8,7 +8,7 @@
 /* 29.04.14  1.00  Lad  The first version of CascCommon.cpp                  */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -8,8 +8,8 @@
 /* 29.04.14  1.00  Lad  The first version of CascCommon.h                    */
 /*****************************************************************************/
 
-#ifndef __CASCCOMMON_H__
-#define __CASCCOMMON_H__
+#ifndef CASCCOMMON_H_
+#define CASCCOMMON_H_
 
 //-----------------------------------------------------------------------------
 // Compression support
@@ -360,4 +360,4 @@ void CascDumpEncodingEntry(TCascStorage * hs, TDumpContext * dc, PCASC_ENCODING_
 void CascDumpFile(const char * szFileName, HANDLE hFile);
 #endif  // _DEBUG
 
-#endif // __CASCCOMMON_H__
+#endif // CASCCOMMON_H_

--- a/src/CascDecompress.cpp
+++ b/src/CascDecompress.cpp
@@ -8,7 +8,7 @@
 /* 02.05.14  1.00  Lad  The first version of CascDecompress.cpp              */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascDecrypt.cpp
+++ b/src/CascDecrypt.cpp
@@ -8,7 +8,7 @@
 /* 31.10.15  1.00  Lad  The first version of CascDecrypt.cpp                 */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascDumpData.cpp
+++ b/src/CascDumpData.cpp
@@ -8,7 +8,7 @@
 /* 07.05.14  1.00  Lad  The first version of CascDumpData.cpp                */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 #include "CascMndx.h"

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -9,7 +9,7 @@
 /* 30.10.15  1.00  Lad  Renamed to CascFiles.cpp                             */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascFindFile.cpp
+++ b/src/CascFindFile.cpp
@@ -8,7 +8,7 @@
 /* 10.05.14  1.00  Lad  The first version of CascFindFile.cpp                */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -36,7 +36,7 @@ extern "C" {
 //  Y - A for ANSI version, U for Unicode version
 //  Z - S for static-linked CRT library, D for multithreaded DLL CRT library
 //
-#if defined(_MSC_VER) && !defined(__CASCLIB_SELF__)
+#if defined(_MSC_VER) && !defined(CASCLIB_SELF__)
 
   #ifdef _DEBUG                                 // DEBUG VERSIONS
     #ifndef _UNICODE

--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -12,8 +12,8 @@
 /* 29.04.14  1.00  Lad  Created                                              */
 /*****************************************************************************/
 
-#ifndef __CASCLIB_H__
-#define __CASCLIB_H__
+#ifndef CASCLIB_H_
+#define CASCLIB_H_
 
 #ifdef _MSC_VER
 #pragma warning(disable:4668)       // 'XXX' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
@@ -220,4 +220,4 @@ void SetLastError(int nError);
 }   // extern "C"
 #endif
 
-#endif  // __CASCLIB_H__
+#endif  // CASCLIB_H_

--- a/src/CascMndx.h
+++ b/src/CascMndx.h
@@ -8,8 +8,8 @@
 /* 15.05.14  1.00  Lad  Created                                              */
 /*****************************************************************************/
 
-#ifndef __CASC_MNDX_ROOT__
-#define __CASC_MNDX_ROOT__
+#ifndef CASC_MNDX_ROOT_
+#define CASC_MNDX_ROOT_
 
 class TFileNameDatabase;
 
@@ -356,4 +356,4 @@ inline bool IS_SINGLE_CHAR_MATCH(TGenericArray & Table, DWORD ItemIndex)
     return ((Table.NameFragArray[ItemIndex].FragOffs & 0xFFFFFF00) == 0xFFFFFF00);
 }
 
-#endif  // __CASC_MNDX_ROOT__
+#endif  // CASC_MNDX_ROOT_

--- a/src/CascOpenFile.cpp
+++ b/src/CascOpenFile.cpp
@@ -8,7 +8,7 @@
 /* 01.05.14  1.00  Lad  The first version of CascOpenFile.cpp                */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -10,7 +10,7 @@
 /* 29.04.14  1.00  Lad  The first version of CascOpenStorage.cpp             */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -9,8 +9,8 @@
 /* 29.04.14  1.00  Lad  Created                                              */
 /*****************************************************************************/
 
-#ifndef __CASCPORT_H__
-#define __CASCPORT_H__
+#ifndef CASCPORT_H_
+#define CASCPORT_H_
 
 #ifndef __cplusplus
   #define bool char
@@ -273,4 +273,4 @@
     #define    BSWAP_ARRAY64_UNSIGNED(a,b)      ConvertUInt64Buffer((a),(b))
 #endif
 
-#endif // __CASCPORT_H__
+#endif // CASCPORT_H_

--- a/src/CascReadFile.cpp
+++ b/src/CascReadFile.cpp
@@ -8,7 +8,7 @@
 /* 01.05.14  1.00  Lad  The first version of CascOpenFile.cpp                */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascRootFile_Diablo3.cpp
+++ b/src/CascRootFile_Diablo3.cpp
@@ -10,7 +10,7 @@
 /* 04.03.15  1.00  Lad  The first version of CascRootFile_Diablo3.cpp        */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascRootFile_Mndx.cpp
+++ b/src/CascRootFile_Mndx.cpp
@@ -9,7 +9,7 @@
 /* 18.05.14  1.00  Lad  The first version of CascMndxRoot.cpp                */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 #include "CascMndx.h"

--- a/src/CascRootFile_Ovr.cpp
+++ b/src/CascRootFile_Ovr.cpp
@@ -8,7 +8,7 @@
 /* 28.10.15  1.00  Lad  The first version of CascRootFile_Ovr.cpp            */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascRootFile_SC1.cpp
+++ b/src/CascRootFile_SC1.cpp
@@ -8,7 +8,7 @@
 /* 28.10.15  1.00  Lad  The first version of CascRootFile_SC1.cpp            */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/CascRootFile_WoW6.cpp
+++ b/src/CascRootFile_WoW6.cpp
@@ -10,7 +10,7 @@
 /* 29.04.14  1.00  Lad  The first version of CascOpenStorage.cpp             */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "CascLib.h"
 #include "CascCommon.h"
 

--- a/src/common/Common.cpp
+++ b/src/common/Common.cpp
@@ -8,7 +8,7 @@
 /* 29.04.14  1.00  Lad  The first version of CascCommon.cpp                  */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -8,8 +8,8 @@
 /* 29.04.14  1.00  Lad  The first version of CascCommon.h                    */
 /*****************************************************************************/
 
-#ifndef __COMMON_H__
-#define __COMMON_H__
+#ifndef COMMON_H_
+#define COMMON_H_
 
 //-----------------------------------------------------------------------------
 // Common macros
@@ -86,4 +86,4 @@ int ScanIndexDirectory(
     void * pvContext
     );
 
-#endif // __COMMON_H__
+#endif // COMMON_H_

--- a/src/common/Directory.cpp
+++ b/src/common/Directory.cpp
@@ -8,7 +8,7 @@
 /* 29.04.14  1.00  Lad  The first version of Directory.cpp                   */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/Directory.h
+++ b/src/common/Directory.h
@@ -8,8 +8,8 @@
 /* 30.10.15  1.00  Lad  The first version of Directory.h                     */
 /*****************************************************************************/
 
-#ifndef __DIRECTORY_H__
-#define __DIRECTORY_H__
+#ifndef DIRECTORY_H_
+#define DIRECTORY_H_
 
 //-----------------------------------------------------------------------------
 // Scanning a directory
@@ -26,4 +26,4 @@ int ScanIndexDirectory(
     void * pvContext
     );
 
-#endif // __DIRECTORY_H__
+#endif // DIRECTORY_H_

--- a/src/common/DumpContext.cpp
+++ b/src/common/DumpContext.cpp
@@ -8,7 +8,7 @@
 /* 16.03.15  1.00  Lad  Created                                              */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/DumpContext.h
+++ b/src/common/DumpContext.h
@@ -8,8 +8,8 @@
 /* 16.03.15  1.00  Lad  Created                                              */
 /*****************************************************************************/
 
-#ifndef __DUMP_CONTEXT_H__
-#define __DUMP_CONTEXT_H__
+#ifndef DUMP_CONTEXT_H_
+#define DUMP_CONTEXT_H_
 
 //-----------------------------------------------------------------------------
 // Defines
@@ -35,4 +35,4 @@ TDumpContext * CreateDumpContext(struct _TCascStorage * hs, const TCHAR * szName
 int dump_print(TDumpContext * dc, const char * szFormat, ...);
 int dump_close(TDumpContext * dc);
 
-#endif  // __DUMP_CONTEXT_H__
+#endif  // DUMP_CONTEXT_H_

--- a/src/common/DynamicArray.cpp
+++ b/src/common/DynamicArray.cpp
@@ -8,7 +8,7 @@
 /* 30.10.15  1.00  Lad  The first version of DynamicArray.cpp                */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/DynamicArray.h
+++ b/src/common/DynamicArray.h
@@ -8,8 +8,8 @@
 /* 30.10.15  1.00  Lad  The first version of DynamicArray.h                  */
 /*****************************************************************************/
 
-#ifndef __DYNAMIC_ARRAY_H__
-#define __DYNAMIC_ARRAY_H__
+#ifndef DYNAMIC_ARRAY_H_
+#define DYNAMIC_ARRAY_H_
 
 //-----------------------------------------------------------------------------
 // Structures
@@ -34,4 +34,4 @@ void Array_Free(PDYNAMIC_ARRAY pArray);
 
 #define Array_Create(pArray, type, ItemCountMax)    Array_Create_(pArray, sizeof(type), ItemCountMax)
 
-#endif // __DYNAMIC_ARRAY__
+#endif // DYNAMIC_ARRAY_

--- a/src/common/FileStream.cpp
+++ b/src/common/FileStream.cpp
@@ -13,7 +13,7 @@
 /* 28.04.14  1.00  Lad  Copied from StormLib                                 */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/FileStream.h
+++ b/src/common/FileStream.h
@@ -8,8 +8,8 @@
 /* 14.04.12  1.00  Lad  The first version of FileStream.h                    */
 /*****************************************************************************/
 
-#ifndef __FILESTREAM_H__
-#define __FILESTREAM_H__
+#ifndef FILESTREAM_H_
+#define FILESTREAM_H_
 
 //-----------------------------------------------------------------------------
 // Flags for file stream
@@ -257,4 +257,4 @@ bool FileStream_Replace(TFileStream * pStream, TFileStream * pNewStream);
 void FileStream_Close(TFileStream * pStream);
 
 
-#endif // __FILESTREAM_H__
+#endif // FILESTREAM_H_

--- a/src/common/ListFile.cpp
+++ b/src/common/ListFile.cpp
@@ -8,7 +8,7 @@
 /* 12.06.04  1.00  Lad  The first version of ListFile.cpp                    */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/ListFile.h
+++ b/src/common/ListFile.h
@@ -8,8 +8,8 @@
 /* 10.05.14  1.00  Lad  The first version of ListFile.h                      */
 /*****************************************************************************/
 
-#ifndef __LISTFILE_H__
-#define __LISTFILE_H__
+#ifndef LISTFILE_H_
+#define LISTFILE_H_
 
 //-----------------------------------------------------------------------------
 // Structures
@@ -51,4 +51,4 @@ PLISTFILE_MAP ListFile_CreateMap(const TCHAR * szListFile);
 const char * ListFile_FindName(PLISTFILE_MAP pListMap, ULONGLONG FileNameHash);
 void ListFile_FreeMap(PLISTFILE_MAP pListMap);
 
-#endif // __LISTFILE_H__
+#endif // LISTFILE_H_

--- a/src/common/Map.cpp
+++ b/src/common/Map.cpp
@@ -8,7 +8,7 @@
 /* 10.06.14  1.00  Lad  The first version of Map.cpp                         */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/Map.h
+++ b/src/common/Map.h
@@ -8,8 +8,8 @@
 /* 10.06.14  1.00  Lad  The first version of Map.h                           */
 /*****************************************************************************/
 
-#ifndef __HASHTOPTR_H__
-#define __HASHTOPTR_H__
+#ifndef HASHTOPTR_H_
+#define HASHTOPTR_H_
 
 //-----------------------------------------------------------------------------
 // Structures
@@ -39,4 +39,4 @@ const char * Map_FindString(PCASC_MAP pMap, const char * szString, const char * 
 bool Map_InsertString(PCASC_MAP pMap, const char * szString, bool bCutExtension);
 void Map_Free(PCASC_MAP pMap);
 
-#endif // __HASHTOPTR_H__
+#endif // HASHTOPTR_H_

--- a/src/common/RootHandler.cpp
+++ b/src/common/RootHandler.cpp
@@ -8,7 +8,7 @@
 /* 09.03.15  1.00  Lad  Created                                              */
 /*****************************************************************************/
 
-#define __CASCLIB_SELF__
+#define CASCLIB_SELF_
 #include "../CascLib.h"
 #include "../CascCommon.h"
 

--- a/src/common/RootHandler.h
+++ b/src/common/RootHandler.h
@@ -8,8 +8,8 @@
 /* 09.03.15  1.00  Lad  Created                                              */
 /*****************************************************************************/
 
-#ifndef __ROOT_HANDLER_H__
-#define __ROOT_HANDLER_H__
+#ifndef ROOT_HANDLER_H_
+#define ROOT_HANDLER_H_
 
 //-----------------------------------------------------------------------------
 // Defines
@@ -93,4 +93,4 @@ void   RootHandler_Dump(struct _TCascStorage * hs, LPBYTE pbRootHandler, DWORD c
 void   RootHandler_Close(TRootHandler * pRootHandler);
 DWORD  RootHandler_GetFileId(TRootHandler * pRootHandler, const char * szFileName);
 
-#endif  // __ROOT_HANDLER_H__
+#endif  // ROOT_HANDLER_H_


### PR DESCRIPTION
Symbols that begin with underscores and double underscores are reserved