### PR TITLE
fix EOL attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,18 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.cpp text
+*.c text
+*.h text
+
 # Declare files that will always have CRLF line endings on checkout.
-*.c text eol=crlf
-*.h text eol=crlf
+*.bat text eol=crlf
 *.sln text eol=crlf
 *.vcproj text eol=crlf
 *.vcxproj text eol=crlf
+*.vcxproj.filters text eol=crlf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary


### PR DESCRIPTION
Here is a small fix to set the .gitattributes. The .cpp were missing as source. The .vcxproj.filters and .bat were missing on the CRLF side. Also the source files have been set to `text` only:

- source files should have native EOL (CRLF windows, LF Mac/Linux) -> `text`
- windows files should have CRLF forced -> `text eol=crlf`

_Note_: some Mac/Linux clients will still see CRLF on checkout, until the files are changed and normalized in the repo. Once normalized, all these text files are actually saved with LF in the repo, even for the Windows files, but the attributes defined above ensure they are converted properly on each client side. Having still a few CRLF on Mac/Linux is not a real issue, since most of the changes come from Windows so i guess it's not even worth forcing the whole repo. All will be adjusted over time :)