### PR TITLE
Remove missing files from CMakeLists.txt and avoid multiple definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(CascLib)
 set(HEADER_FILES
     src/CascCommon.h
     src/CascLib.h
+	src/CascLib.def
     src/CascPort.h
     src/common/Array.h
     src/common/Common.h
@@ -22,7 +23,6 @@ set(SRC_FILES
     src/common/FileStream.cpp
     src/common/FileTree.cpp
     src/common/ListFile.cpp
-    src/common/Map.cpp
     src/common/RootHandler.cpp
     src/jenkins/lookup3.c
     src/CascCommon.cpp

--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -24,7 +24,6 @@
 #include "CascPort.h"
 #include "common/Common.h"
 #include "common/Array.h"
-#include "common/IndexMap.h"
 #include "common/Map.h"
 #include "common/FileTree.h"
 #include "common/FileStream.h"

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -252,7 +252,7 @@ static bool CheckConfigFileVariable(
         return false;
 
     // Verify whether this is the variable
-    if (!CheckWildCard(szVariableName, szVarName))
+    if (!CascCheckWildCard(szVariableName, szVarName))
         return false;
 
     // Skip the spaces and '='

--- a/src/CascReadFile.cpp
+++ b/src/CascReadFile.cpp
@@ -402,7 +402,7 @@ static int LoadEncodedFrame(TFileStream * pStream, PCASC_FILE_FRAME pFrame, LPBY
     {
         if (bVerifyIntegrity)
         {
-            if (!VerifyDataBlockHash(pbEncodedFrame, pFrame->EncodedSize, pFrame->FrameHash.Value))
+            if (!CascVerifyDataBlockHash(pbEncodedFrame, pFrame->EncodedSize, pFrame->FrameHash.Value))
                 nError = ERROR_FILE_CORRUPT;
         }
     }

--- a/src/CascRootFile_MNDX.cpp
+++ b/src/CascRootFile_MNDX.cpp
@@ -2766,7 +2766,7 @@ struct TRootHandler_MNDX : public TRootHandler
         int nError;
 
         // Filter the file names by wildcard
-        if(!CheckWildCard(szFileName, szWildCard))
+        if(!CascCheckWildCard(szFileName, szWildCard))
             return NULL;
 
         // We need the normalized name here

--- a/src/common/Common.cpp
+++ b/src/common/Common.cpp
@@ -529,7 +529,7 @@ bool IsFileCKeyEKeyName(const char * szFileName, LPBYTE PtrKeyBuffer)
     return false;
 }
 
-bool CheckWildCard(const char * szString, const char * szWildCard)
+bool CascCheckWildCard(const char * szString, const char * szWildCard)
 {
     const char * szWildCardPtr;
 
@@ -561,7 +561,7 @@ bool CheckWildCard(const char * szString, const char * szWildCard)
 
                 if(AsciiToUpperTable_BkSlash[szWildCardPtr[0]] == AsciiToUpperTable_BkSlash[szString[0]])
                 {
-                    if(CheckWildCard(szString, szWildCardPtr))
+                    if(CascCheckWildCard(szString, szWildCardPtr))
                         return true;
                 }
             }
@@ -588,7 +588,7 @@ bool CheckWildCard(const char * szString, const char * szWildCard)
 //-----------------------------------------------------------------------------
 // Hashing functions
 
-bool IsValidMD5(LPBYTE pbMd5)
+bool CascIsValidMD5(LPBYTE pbMd5)
 {
     PDWORD Int32Array = (LPDWORD)pbMd5;
 
@@ -596,13 +596,13 @@ bool IsValidMD5(LPBYTE pbMd5)
     return (Int32Array[0] | Int32Array[1] | Int32Array[2] | Int32Array[3]) ? true : false;
 }
 
-bool VerifyDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE expected_md5)
+bool CascVerifyDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE expected_md5)
 {
     hash_state md5_state;
     BYTE md5_digest[MD5_HASH_SIZE];
 
     // Don't verify the block if the MD5 is not valid.
-    if(!IsValidMD5(expected_md5))
+    if(!CascIsValidMD5(expected_md5))
         return true;
 
     // Calculate the MD5 of the data block
@@ -614,7 +614,7 @@ bool VerifyDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE expected_
     return (memcmp(md5_digest, expected_md5, MD5_HASH_SIZE) == 0);
 }
 
-void CalculateDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE md5_hash)
+void CascCalculateDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE md5_hash)
 {
     hash_state md5_state;
 

--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -300,16 +300,16 @@ const XCHAR * GetFileExtension(const XCHAR * szFileName)
 bool IsFileDataIdName(const char * szFileName, DWORD & FileDataId);
 bool IsFileCKeyEKeyName(const char * szFileName, LPBYTE PtrKeyBuffer);
 
-bool CheckWildCard(const char * szString, const char * szWildCard);
+bool CascCheckWildCard(const char * szString, const char * szWildCard);
 
 //-----------------------------------------------------------------------------
 // Hashing functions
 
 ULONGLONG HashStringJenkins(const char * szFileName);
 
-bool IsValidMD5(LPBYTE pbMd5);
-void CalculateDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE md5_hash);
-bool VerifyDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE expected_md5);
+bool CascIsValidMD5(LPBYTE pbMd5);
+void CascCalculateDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE md5_hash);
+bool CascVerifyDataBlockHash(void * pvDataBlock, DWORD cbDataBlock, LPBYTE expected_md5);
 
 //-----------------------------------------------------------------------------
 // Scanning a directory

--- a/src/common/ListFile.cpp
+++ b/src/common/ListFile.cpp
@@ -181,7 +181,7 @@ bool ListFile_VerifyMD5(void * pvListFile, LPBYTE pbHashMD5)
     assert(pCache->pPos == pCache->pBegin);
 
     // Verify the MD5 hash for the entire block
-    return VerifyDataBlockHash(pCache->pBegin, (DWORD)(pCache->pEnd - pCache->pBegin), pbHashMD5);
+    return CascVerifyDataBlockHash(pCache->pBegin, (DWORD)(pCache->pEnd - pCache->pBegin), pbHashMD5);
 }
 
 size_t ListFile_GetNextLine(void * pvListFile, const char ** pszLineBegin, const char ** pszLineEnd)
@@ -274,7 +274,7 @@ size_t ListFile_GetNext(void * pvListFile, const char * szMask, char * szBuffer,
         }
 
         // If some mask entered, check it
-        if(CheckWildCard(szBuffer, szMask))
+        if(CascCheckWildCard(szBuffer, szMask))
         {
             PtrFileDataId[0] = FileDataId;
             nError = ERROR_SUCCESS;

--- a/src/common/RootHandler.cpp
+++ b/src/common/RootHandler.cpp
@@ -77,7 +77,7 @@ PCASC_CKEY_ENTRY TFileTreeRoot::Search(TCascSearch * pSearch, PCASC_FIND_DATA pF
             if(!(pFileNode->Flags & CFN_FLAG_FOLDER))
             {
                 // Check the wildcard
-                if (CheckWildCard(pFindData->szFileName, pSearch->szMask))
+                if (CascCheckWildCard(pFindData->szFileName, pSearch->szMask))
                 {
                     // Retrieve the extra values (FileDataId, file size and locale flags)
                     FileTree.GetExtras(pFileNode, &pFindData->dwFileDataId, &pFindData->dwLocaleFlags, &pFindData->dwContentFlags);


### PR DESCRIPTION
There was a file mentioned in the CMakeLists.txt that does not exist. Furthermore common/IndexMap.h also does not exist. Finally I renamed some functions so that the library can easily be used together with StormLib without getting compile errors.

This was mentioned earlier [here](https://github.com/ladislav-zezula/CascLib/issues/111), but the proposed solution is not preferable and the fix is simple.