### PR TITLE
Allow excluding #pragma comment for windows cmake users

### DIFF
--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -36,7 +36,7 @@ extern "C" {
 //  Y - A for ANSI version, U for Unicode version
 //  Z - S for static-linked CRT library, D for multithreaded DLL CRT library
 //
-#if defined(_MSC_VER) && !defined(__CASCLIB_SELF__)
+#if defined(_MSC_VER) && !defined(__CASCLIB_SELF__) && !defined(CASCLIB_NO_AUTO_LINK_LIBRARY)
 
   #ifdef _DEBUG                                 // DEBUG VERSIONS
     #ifndef _UNICODE


### PR DESCRIPTION
At TrinityCore we build CascLib from source using our own simplified CMakeLists.txt so every time I upgrade the lib I need to rip out these #pragma comment statements (because lib name is always casc.lib)

This change simplifies my upgrade process