### PR TITLE
Allow selecting which installed product to open storage for

### DIFF
--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -218,7 +218,7 @@ struct TCascStorage
     TCHAR * szBuildFile;                            // Build file name (.build.info or .build.db)
     TCHAR * szCdnServers;                           // Multi-SZ list of CDN servers
     TCHAR * szCdnPath;                              // Remote CDN sub path for the product
-    TCHAR * szCodeName;                             // Product code name. Only for online storages
+    TCHAR * szCodeName;                             // Product code name. Only for online storages and optionally for local World of Warcraft storages
     char * szRegion;                                // Product region. Only when "versions" is used as storage root file
     CASC_PRODUCT Product;                           // Product enum value (see CASC_PRODUCT)
     DWORD dwBuildNumber;                            // Product build number

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -600,6 +600,10 @@ static int ParseFile_BuildInfo(TCascStorage * hs, CASC_CSV & Csv)
 {
     size_t nLineCount = Csv.GetLineCount();
     int nError;
+    char szCodeNameC[0x40];
+
+    if (hs->szCodeName != NULL)
+        CascStrCopy(szCodeNameC, _countof(szCodeNameC), hs->szCodeName);
 
     // Find the active config
     for(size_t i = 0; i < nLineCount; i++)
@@ -607,6 +611,15 @@ static int ParseFile_BuildInfo(TCascStorage * hs, CASC_CSV & Csv)
         // Is that build config active?
         if (!strcmp(Csv[i]["Active!DEC:1"].szValue, "1"))
         {
+            if (hs->szCodeName != NULL)
+            {
+                // World of Warcraft can have multiple different products share the same install directory
+                // If user requested a specific product, choose only that
+                const CASC_CSV_COLUMN& ProductColumn = Csv[i]["Product!STRING:0"];
+                if (ProductColumn.szValue && ProductColumn.nLength && strcmp(ProductColumn.szValue, szCodeNameC) != 0)
+                    continue;
+            }
+
             // Extract the CDN build key
             nError = LoadQueryKey(Csv[i]["Build Key!HEX:16"], hs->CdnBuildKey);
             if (nError != ERROR_SUCCESS)

--- a/src/CascLib.def
+++ b/src/CascLib.def
@@ -9,9 +9,11 @@ LIBRARY CascLib.dll
 EXPORTS
 
     CascOpenStorage
+    CascOpenStorageEx
     CascOpenOnlineStorage
     CascGetStorageInfo
     CascAddEncryptionKey
+    CascFindEncryptionKey
     CascCloseStorage
 
     CascOpenFile

--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -269,6 +269,12 @@ typedef struct _CASC_STORAGE_PRODUCT
 
 } CASC_STORAGE_PRODUCT, *PCASC_STORAGE_PRODUCT;
 
+typedef struct _CASC_OPEN_STORAGE_ARGS
+{
+    size_t Size;
+    LPCSTR szCodeName;
+} CASC_OPEN_STORAGE_ARGS, *PCASC_OPEN_STORAGE_ARGS;
+
 typedef struct _CASC_FILE_FULL_INFO
 {
     BYTE CKey[MD5_HASH_SIZE];                   // CKey
@@ -309,6 +315,7 @@ void WINAPI CascSetProgressCallback(
 // Functions for storage manipulation
 
 bool  WINAPI CascOpenStorage(LPCTSTR szDataPath, DWORD dwLocaleMask, HANDLE * phStorage);
+bool  WINAPI CascOpenStorageEx(LPCTSTR szDataPath, DWORD dwLocaleMask, PCASC_OPEN_STORAGE_ARGS pArgs, HANDLE * phStorage);
 bool  WINAPI CascOpenOnlineStorage(LPCTSTR szLocalCache, LPCSTR szCodeName, LPCSTR szRegion, DWORD dwLocaleMask, HANDLE * phStorage);
 bool  WINAPI CascGetStorageInfo(HANDLE hStorage, CASC_STORAGE_INFO_CLASS InfoClass, void * pvStorageInfo, size_t cbStorageInfo, size_t * pcbLengthNeeded);
 bool  WINAPI CascAddEncryptionKey(HANDLE hStorage, ULONGLONG KeyName, LPBYTE Key);

--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -383,4 +383,21 @@ int ScanIndexDirectory(
     void * pvContext
     );
 
+//-----------------------------------------------------------------------------
+// Argument structure versioning
+// Safely retrieves field value from a structure
+// intended for cases where users upgrade CascLib by simply dropping in a new .dll without recompiling their app
+template <typename ARG, typename ARG_HOLDER>
+bool ExtractVersionedArgument(const ARG_HOLDER * pHolder, size_t ArgOffset, ARG * pArg)
+{
+    if (pHolder == NULL)
+        return false;
+
+    // Check input structure size
+    if (ArgOffset + sizeof(ARG) > pHolder->Size)
+        return false;
+
+    *pArg = *((ARG *)(((char*)pHolder) + ArgOffset));
+}
+
 #endif // __COMMON_H__


### PR DESCRIPTION
World of Warcraft supports installing multiple products into the same directory to minimize disk usage

.build.info for such configuration looks like this
```
Branch!STRING:0|Active!DEC:1|Build Key!HEX:16|CDN Key!HEX:16|Install Key!HEX:16|IM Size!DEC:4|CDN Path!STRING:0|CDN Hosts!STRING:0|CDN Servers!STRING:0|Tags!STRING:0|Armadillo!STRING:0|Last Activated!STRING:0|Version!STRING:0|Product!STRING:0|Build Complete!DEC:1
eu|1|d3192b18729bb6f00c595fd37097c19f|3bb4ba6bf2d4c855639247abf80fd6aa|8bafcfcf55c7933486336bef35aa2d3f||tpr/wow|eu.cdn.blizzard.com level3.blizzard.com|http://eu.cdn.blizzard.com/?maxhosts=4 http://level3.blizzard.com/?maxhosts=4 https://blzddist1-a.akamaihd.net/?fallback=1&maxhosts=4 https://eu.cdn.blizzard.com/?fallback=1&maxhosts=4 https://level3.ssl.blizzard.com/?fallback=1&maxhosts=4|Windows x86_64 EU? acct-POL? geoip-PL? enUS speech?:Windows x86_64 EU? acct-POL? geoip-PL? enUS text?||2019-06-15T08:02:01Z|8.1.5.30706|wow|1
eu|1|9c48c4c500f8e9e3f3a5de6403e967d7|3bb4ba6bf2d4c855639247abf80fd6aa|597b4796d7d69e83c43c2423934b78bb||tpr/wow|us.cdn.blizzard.com level3.blizzard.com|http://level3.blizzard.com/?maxhosts=4 http://us.cdn.blizzard.com/?maxhosts=4 https://blzddist1-a.akamaihd.net/?fallback=1&maxhosts=4 https://level3.ssl.blizzard.com/?fallback=1&maxhosts=4 https://us.cdn.blizzard.com/?fallback=1&maxhosts=4|Windows x86_64 EU? acct-POL? geoip-PL? enUS speech?:Windows x86_64 EU? acct-POL? geoip-PL? enUS text?||2019-06-15T09:13:54Z|8.2.0.30827|wowt|1
```

Multiple builds marked as Active, Product column determines what to open

I was not sure how much you care about backwards compatibility so I added new (expandable) function `CascOpenStorageEx` designed in similar way to WINAPI functions that accept a structure where you must set their size member. If this is unneccessarily complicated/unneeded I can change it