### PR TITLE
Fix mac build

### DIFF
--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -87,6 +87,7 @@
   #include <errno.h>
   #include <stddef.h>
   #include <string.h>
+  #include <ctype.h>
   #include <cassert>
 
   // Support for PowerPC on Max OS X


### PR DESCRIPTION
Fix mac build. Probably. (no mac to test, mac vms are a pain too)

This include is needed for `isxdigit` here
https://github.com/ladislav-zezula/CascLib/blob/57a26ab26ff23d07e870044c4971d7a51488e9d6/src/CascFiles.cpp#L161