### PR TITLE
Restore compilation under Linux

### DIFF
--- a/src/CascRootFile_TVFS.cpp
+++ b/src/CascRootFile_TVFS.cpp
@@ -397,7 +397,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         return dwErrCode;
     }
 
-    PCASC_CKEY_ENTRY InsertUnknownCKeyEntry(TCascStorage * hs, LPBYTE pbEKey, size_t cbEKey, ULONG ContentSize)
+    PCASC_CKEY_ENTRY InsertUnknownCKeyEntry(TCascStorage * hs, LPBYTE pbEKey, size_t cbEKey, DWORD ContentSize)
     {
         PCASC_CKEY_ENTRY pCKeyEntry;
 


### PR DESCRIPTION
ULONG is not defined with Clang on Ubuntu. The function InsertUnknownCKeyEntry is called with CASC_CKEY_ENTRY.ContentSize as last parameter, which is DWORD. Thus the change