### PR TITLE
Fix Mac compilation

### DIFF
--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -80,17 +80,19 @@
   #include <sys/types.h>
   #include <sys/stat.h>
   #include <sys/mman.h>
-  #include <unistd.h>
   #include <fcntl.h>
-  #include <stdlib.h>
   #include <dirent.h>
-  #include <errno.h>
+  #include <unistd.h>
   #include <stddef.h>
+  #include <stdint.h>
+  #include <stdlib.h>
+  #include <stdio.h>
+  #include <stdarg.h>
   #include <string.h>
   #include <ctype.h>
+  #include <wchar.h>
   #include <cassert>
-  #include <cwchar>
-  #include <cstdio>
+  #include <errno.h>
 
   // Support for PowerPC on Max OS X
   #if (__ppc__ == 1) || (__POWERPC__ == 1) || (_ARCH_PPC == 1)


### PR DESCRIPTION
These small changes fix Mac compilation so that CascLib can be compiled by the [vcpkg](https://github.com/microsoft/vcpkg/) Mac environment.