### PR TITLE
Fix loading locale specific files

### DIFF
--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -1202,7 +1202,10 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs)
         // Failing to select storage on them will lead to the first-in-order file in the list being loaded.
         // Example: WoW build 32144, file: DBFilesClient\Achievement.db2, file data ID: 1260179
         // Locales: koKR frFR deDE zhCN esES zhTW enUS&enGB esMX ruRU itIT ptBT&ptPT (in order of appearance in the build manifest)
-        dwLocaleMask = (dwLocaleMask == 0) ? hs->dwDefaultLocale : 0;
+        if(dwLocaleMask == 0)
+        {
+            dwLocaleMask = hs->dwDefaultLocale;
+        }
 
         // Continue loading the manifest
         dwErrCode = LoadBuildManifest(hs, dwLocaleMask);


### PR DESCRIPTION
I believe f3cb5f10dd4290a1649ac815fdc270ed0827a6e8 is the commit that broke loading all locale-specific files (didn't try to bisect, I upgraded from b91f87c770c78340dcd96df970e55b5c0469e884 to 8130478a7918350e2fbdb7c5a0723a700820b1cb)

Original code is the locale mask to 0 when proper locales are given to CascOpenStorage, resulting in none of the locale-specific files being available for reading