### PR TITLE
Fix error: 'UNREFERENCED_PARAMETER' was not declared in this scope

### DIFF
--- a/test/CascTest.cpp
+++ b/test/CascTest.cpp
@@ -44,6 +44,7 @@
 #ifdef PLATFORM_LINUX
 #define CASC_PATH_ROOT "/mnt/casc"
 #define CASC_WORK_ROOT "/mnt/casc/Work"
+#define UNREFERENCED_PARAMETER(var) (void)var;
 #endif
 
 static const char szCircleChar[] = "|/-\\";


### PR DESCRIPTION
Fix https://github.com/ladislav-zezula/CascLib/issues/173