### PR TITLE
Fix macOS build.

### DIFF
--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -100,6 +100,7 @@
   #include <wchar.h>
   #include <cassert>
   #include <errno.h>
+  #include <pthread.h>
 
   // Support for PowerPC on Max OS X
   #if (__ppc__ == 1) || (__POWERPC__ == 1) || (_ARCH_PPC == 1)


### PR DESCRIPTION
This PR fixed build errors on macOS Catalina:
```
/Users/fluxxu/Projects/CascLib/src/CascReadFile.cpp:44:9: Use of undeclared identifier 'pthread_mutex_lock'
/Users/fluxxu/Projects/CascLib/src/CascReadFile.cpp:60:9: Use of undeclared identifier 'pthread_mutex_unlock'
```