### PR TITLE
remove warnings on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /*.cmake
 /Makefile
 /CMakeScripts/
+/build/
 
 # Visual Studio related files
 *.opensdf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.2)
 project(CascLib)
 
 set(HEADER_FILES
@@ -99,6 +99,18 @@ option(CASC_BUILD_SHARED_LIB "Compile dynamically linked library" ON)
 if(CASC_BUILD_SHARED_LIB)
     message(STATUS "Build dynamically linked library")
     add_library(casc SHARED ${SRC_FILES} ${HEADER_FILES} ${SRC_ADDITIONAL_FILES})
+
+    if(APPLE)
+        set_target_properties(casc PROPERTIES FRAMEWORK true)
+        set_target_properties(casc PROPERTIES PUBLIC_HEADER "src/CascLib.h src/CascPort.h")
+        set_target_properties(casc PROPERTIES LINK_FLAGS "-framework Carbon")
+    endif()
+
+    if(UNIX)
+        set_target_properties(casc PROPERTIES VERSION 1.0.0)
+        set_target_properties(casc PROPERTIES SOVERSION 1)
+    endif()
+	
     target_link_libraries(casc ${LINK_LIBS})
     install(TARGETS casc RUNTIME DESTINATION bin LIBRARY DESTINATION lib${LIB_SUFFIX} ARCHIVE DESTINATION lib${LIB_SUFFIX} FRAMEWORK DESTINATION /Library/Frameworks)
     target_include_directories(casc
@@ -111,23 +123,11 @@ if(CASC_BUILD_SHARED_LIB)
         set_target_properties(casc PROPERTIES OUTPUT_NAME CascLib)
     endif()
 
-
-if(APPLE)
-    set_target_properties(casc PROPERTIES FRAMEWORK true)
-    set_target_properties(casc PROPERTIES PUBLIC_HEADER "src/CascLib.h src/CascPort.h")
-    set_target_properties(casc PROPERTIES LINK_FLAGS "-framework Carbon")
-endif()
-
-if(UNIX)
-    set_target_properties(casc PROPERTIES VERSION 1.0.0)
-    set_target_properties(casc PROPERTIES SOVERSION 1)
-endif()
-
 endif()
 
 option(CASC_BUILD_TESTS "Build Test application" OFF)
 if(CASC_BUILD_TESTS)
-    set(CASC_BUILD_STATIC_LIB ON CACHE BOOL "Force Static library building to link test app")
+    set(CASC_BUILD_STATIC_LIB ON CACHE BOOL "Force Static library building to link test app" FORCE)
     message(STATUS "Build Test application")
     add_executable(casc_test ${TEST_SRC_FILES})
     set_target_properties(casc_test PROPERTIES LINK_FLAGS "-pthread")

--- a/src/CascDumpData.cpp
+++ b/src/CascDumpData.cpp
@@ -530,4 +530,9 @@ void CascDumpStorage(HANDLE hStorage, const char * szDumpFile)
     }
 }
 
+#else // _DEBUG
+
+// so linker won't mind this .cpp file is empty in non-DEBUG builds
+void unused_symbol() { }
+
 #endif // _DEBUG

--- a/src/CascReadFile.cpp
+++ b/src/CascReadFile.cpp
@@ -48,7 +48,7 @@ static DWORD OpenDataStream(TCascFile * hf, PCASC_FILE_SPAN pFileSpan, PCASC_CKE
         {
             // Prepare the name of the data file
             CascStrPrintf(szPlainName, _countof(szPlainName), _T("data.%03u"), dwArchiveIndex);
-            CombinePath(szDataFile, _countof(szDataFile), PATH_SEP_CHAR, hs->szIndexPath, szPlainName, NULL);
+            CombinePath(szDataFile, _countof(szDataFile), PATH_SEP_CHAR, {hs->szIndexPath, szPlainName});
 
             // Open the data stream with read+write sharing to prevent Battle.net agent
             // detecting a corruption and redownloading the entire package
@@ -1256,6 +1256,9 @@ bool WINAPI CascReadFile(HANDLE hFile, void * pvBuffer, DWORD dwBytesToRead, PDW
         case CascCacheLastFrame:
             dwBytesRead2 = ReadFile_FrameCached(hf, pbBuffer, StartOffset, EndOffset);
             break;
+
+        default:;
+            // to remove warning
     }
 
     // If the second-stage-read failed, we invalidate the entire operation and return 0 bytes read

--- a/src/common/Common.cpp
+++ b/src/common/Common.cpp
@@ -454,32 +454,20 @@ bool CutLastPathPart(LPTSTR szWorkPath)
     return true;
 }
 
-size_t CombinePath(LPTSTR szBuffer, size_t nMaxChars, char chSeparator, va_list argList)
+size_t CombinePath(LPTSTR szBuffer, size_t nMaxChars, char chSeparator, std::initializer_list<LPCTSTR> argList)
 {
     CASC_PATH<TCHAR> Path(chSeparator);
     LPCTSTR szFragment;
     bool bWithSeparator = false;
 
     // Combine all parts of the path here
-    while((szFragment = va_arg(argList, LPTSTR)) != NULL)
+    for (LPCTSTR szFragment: argList)
     {
         Path.AppendString(szFragment, bWithSeparator);
         bWithSeparator = true;
     }
 
     return Path.Copy(szBuffer, nMaxChars);
-}
-
-size_t CombinePath(LPTSTR szBuffer, size_t nMaxChars, char chSeparator, ...)
-{
-    va_list argList;
-    size_t nLength;
-
-    va_start(argList, chSeparator);
-    nLength = CombinePath(szBuffer, nMaxChars, chSeparator, argList);
-    va_end(argList);
-
-    return nLength;
 }
 
 LPTSTR CombinePath(LPCTSTR szDirectory, LPCTSTR szSubDir)

--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -11,6 +11,8 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
+#include <initializer_list>
+
 //-----------------------------------------------------------------------------
 // Common macros
 
@@ -328,8 +330,7 @@ wchar_t * CascNewStr(const wchar_t * szString, size_t nCharsToReserve = 0);
 LPSTR  CascNewStrT2A(LPCTSTR szString, size_t nCharsToReserve = 0);
 LPTSTR CascNewStrA2T(LPCSTR szString, size_t nCharsToReserve = 0);
 
-size_t CombinePath(LPTSTR szBuffer, size_t nMaxChars, char chSeparator, va_list argList);
-size_t CombinePath(LPTSTR szBuffer, size_t nMaxChars, char chSeparator, ...);
+size_t CombinePath(LPTSTR szBuffer, size_t nMaxChars, char chSeparator, std::initializer_list<LPCTSTR> parts);
 LPTSTR CombinePath(LPCTSTR szPath, LPCTSTR szSubDir);
 LPTSTR GetLastPathPart(LPTSTR szWorkPath);
 bool CutLastPathPart(LPTSTR szWorkPath);

--- a/src/common/Mime.cpp
+++ b/src/common/Mime.cpp
@@ -337,6 +337,9 @@ DWORD CASC_MIME_ELEMENT::Load(char * mime_data_begin, char * mime_data_end, cons
                     case MimeEncodingBase64:
                         dwErrCode = DecodeBase64(content.ptr, content.end, data_buffer, &data_length);
                         break;
+                    
+                    default:;
+                        // to remove warning
                 }
 
                 // If failed, free the buffer back


### PR DESCRIPTION
- remove warning in cmake, bump version to something reasonable modern
- remove warning about zero symbols in CascDumpData
- remove of using va_arg in CombinePath, using std::initializer_list instead
- remove warning in two switches about missing case