### PR TITLE
Preprocessor cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 
 if(APPLE)
     message(STATUS "Using Mac OS X port")
-    set(LINK_LIBS z bz2)
+    set(LINK_LIBS z)
     set(SRC_ADDITIONAL_FILES)
 endif()
 

--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -97,7 +97,6 @@
 
   #define    PKEXPORT
   #define    __SYS_ZLIB
-  #define    __SYS_BZLIB
 
   #ifndef __BIG_ENDIAN__
     #define CASCLIB_PLATFORM_LITTLE_ENDIAN

--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -21,7 +21,7 @@
 //-----------------------------------------------------------------------------
 // Defines for Windows
 
-#if !defined(PLATFORM_DEFINED) && (defined(_WIN32) || defined(_WIN64))
+#if !defined(CASCLIB_PLATFORM_DEFINED) && (defined(_WIN32) || defined(_WIN64))
 
   // In MSVC 8.0, there are some functions declared as deprecated.
   #define _CRT_SECURE_NO_DEPRECATE
@@ -46,7 +46,7 @@
   #include <ws2tcpip.h>
   #include <strsafe.h>
 
-  #define PLATFORM_LITTLE_ENDIAN
+  #define CASCLIB_PLATFORM_LITTLE_ENDIAN
 
   #pragma intrinsic(memset, memcmp, memcpy)     // Make these functions intrinsic (inline)
 
@@ -54,8 +54,8 @@
   #define PATH_SEP_CHAR             '\\'
   #define PATH_SEP_STRING           "\\"
 
-  #define PLATFORM_WINDOWS
-  #define PLATFORM_DEFINED                      // The platform is known now
+  #define CASCLIB_PLATFORM_WINDOWS
+  #define CASCLIB_PLATFORM_DEFINED              // The platform is known now
 
 #endif
 
@@ -66,7 +66,7 @@
 //-----------------------------------------------------------------------------
 // Defines for Mac
 
-#if !defined(PLATFORM_DEFINED) && defined(__APPLE__)  // Mac BSD API
+#if !defined(CASCLIB_PLATFORM_DEFINED) && defined(__APPLE__)  // Mac BSD API
 
   // Macintosh
   #include <sys/types.h>
@@ -100,7 +100,7 @@
   #define    __SYS_BZLIB
 
   #ifndef __BIG_ENDIAN__
-    #define PLATFORM_LITTLE_ENDIAN
+    #define CASCLIB_PLATFORM_LITTLE_ENDIAN
   #endif
 
   #define URL_SEP_CHAR              '/'
@@ -109,15 +109,15 @@
 
   typedef int SOCKET;
 
-  #define PLATFORM_MAC
-  #define PLATFORM_DEFINED                  // The platform is known now
+  #define CASCLIB_PLATFORM_MAC
+  #define CASCLIB_PLATFORM_DEFINED          // The platform is known now
 
 #endif
 
 //-----------------------------------------------------------------------------
 // Assumption: we are not on Windows nor Macintosh, so this must be linux *grin*
 
-#if !defined(PLATFORM_DEFINED)
+#if !defined(CASCLIB_PLATFORM_DEFINED)
   #include <sys/types.h>
   #include <sys/stat.h>
   #include <sys/socket.h>
@@ -144,16 +144,16 @@
 
   typedef int SOCKET;
 
-  #define PLATFORM_LITTLE_ENDIAN
-  #define PLATFORM_LINUX
-  #define PLATFORM_DEFINED
+  #define CASCLIB_PLATFORM_LITTLE_ENDIAN
+  #define CASCLIB_PLATFORM_LINUX
+  #define CASCLIB_PLATFORM_DEFINED
 
 #endif
 
 //-----------------------------------------------------------------------------
 // Definition of Windows-specific types for non-Windows platforms
 
-#ifndef PLATFORM_WINDOWS
+#ifndef CASCLIB_PLATFORM_WINDOWS
 
   // Typedefs for ANSI C
   typedef unsigned char  BYTE;
@@ -213,10 +213,10 @@
 
   #define closesocket close
 
-#endif // !PLATFORM_WINDOWS
+#endif // !CASCLIB_PLATFORM_WINDOWS
 
 // 64-bit calls are supplied by "normal" calls on Mac
-#if defined(PLATFORM_MAC)
+#if defined(CASCLIB_PLATFORM_MAC)
   #define stat64  stat
   #define fstat64 fstat
   #define lseek64 lseek
@@ -226,7 +226,7 @@
 #endif
 
 // Platform-specific error codes for UNIX-based platforms
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
   #define ERROR_SUCCESS                  0
   #define ERROR_FILE_NOT_FOUND           ENOENT
   #define ERROR_PATH_NOT_FOUND           ENOENT
@@ -276,7 +276,7 @@
 //-----------------------------------------------------------------------------
 // Swapping functions
 
-#ifdef PLATFORM_LITTLE_ENDIAN
+#ifdef CASCLIB_PLATFORM_LITTLE_ENDIAN
     #define    BSWAP_INT16_UNSIGNED(a)          (a)
     #define    BSWAP_INT16_SIGNED(a)            (a)
     #define    BSWAP_INT32_UNSIGNED(a)          (a)
@@ -319,7 +319,7 @@
 
 inline DWORD CascInterlockedIncrement(DWORD * PtrValue)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     return (DWORD)InterlockedIncrement((LONG *)(PtrValue));
 #elif defined(__GNUC__)
     return __sync_add_and_fetch(PtrValue, 1);
@@ -331,7 +331,7 @@ inline DWORD CascInterlockedIncrement(DWORD * PtrValue)
 
 inline DWORD CascInterlockedDecrement(DWORD * PtrValue)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     return (DWORD)InterlockedDecrement((LONG *)(PtrValue));
 #elif defined(__GNUC__)
     return __sync_sub_and_fetch(PtrValue, 1);
@@ -343,7 +343,7 @@ inline DWORD CascInterlockedDecrement(DWORD * PtrValue)
 //-----------------------------------------------------------------------------
 // Lock functions
 
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
 
 typedef RTL_CRITICAL_SECTION CASC_LOCK;
 #define CascInitLock(Lock)      InitializeCriticalSection(&Lock);

--- a/src/CascPort.h
+++ b/src/CascPort.h
@@ -96,7 +96,10 @@
   #endif
 
   #define    PKEXPORT
-  #define    __SYS_ZLIB
+
+  #ifndef __SYS_ZLIB
+    #define    __SYS_ZLIB
+  #endif
 
   #ifndef __BIG_ENDIAN__
     #define CASCLIB_PLATFORM_LITTLE_ENDIAN

--- a/src/common/Common.cpp
+++ b/src/common/Common.cpp
@@ -81,7 +81,7 @@ static DWORD dwLastError = ERROR_SUCCESS;
 
 DWORD GetCascError()
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     return GetLastError();
 #else
     return dwLastError;
@@ -90,7 +90,7 @@ DWORD GetCascError()
 
 void SetCascError(DWORD dwErrCode)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     SetLastError(dwErrCode);
 #endif
     dwLastError = dwErrCode;
@@ -301,7 +301,7 @@ size_t CascStrPrintf(char * buffer, size_t nCount, const char * format, ...)
     // Start the argument list
     va_start(argList, format);
     
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     StringCchVPrintfExA(buffer, nCount, &buffend, NULL, 0, format, argList);
 //  buffend = buffer + vsnprintf(buffer, nCount, format, argList);
 #else
@@ -321,7 +321,7 @@ size_t CascStrPrintf(wchar_t * buffer, size_t nCount, const wchar_t * format, ..
     // Start the argument list
     va_start(argList, format);
 
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     StringCchVPrintfExW(buffer, nCount, &buffend, NULL, 0, format, argList);
 //  buffend = buffer + vswprintf(buffer, nCount, format, argList);
 #else

--- a/src/common/Directory.cpp
+++ b/src/common/Directory.cpp
@@ -17,13 +17,13 @@
 
 bool DirectoryExists(LPCTSTR szDirectory)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
 
     DWORD dwAttributes = GetFileAttributes(szDirectory);
     if((dwAttributes != INVALID_FILE_ATTRIBUTES) && (dwAttributes & FILE_ATTRIBUTE_DIRECTORY))
         return true;
 
-#else // PLATFORM_WINDOWS
+#else // CASCLIB_PLATFORM_WINDOWS
 
     DIR * dir = opendir(szDirectory);
 
@@ -40,7 +40,7 @@ bool DirectoryExists(LPCTSTR szDirectory)
 
 bool MakeDirectory(LPCTSTR szDirectory)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
 
     BOOL bResult = CreateDirectory(szDirectory, NULL);
     return (bResult) ? true : false;
@@ -57,7 +57,7 @@ int ScanIndexDirectory(
     INDEX_FILE_FOUND pfnOnFileFound,
     void * pvContext)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
 
     WIN32_FIND_DATA wf;
     HANDLE hFind;
@@ -85,7 +85,7 @@ int ScanIndexDirectory(
         FindClose(hFind);
     }
 
-#else // PLATFORM_WINDOWS
+#else // CASCLIB_PLATFORM_WINDOWS
 
     struct dirent * dir_entry;
     DIR * dir;

--- a/src/common/FileStream.cpp
+++ b/src/common/FileStream.cpp
@@ -55,7 +55,7 @@ static void BaseNone_Init(TFileStream *)
 
 static bool BaseFile_Create(TFileStream * pStream)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     {
         DWORD dwWriteShare = (pStream->dwFlags & STREAM_FLAG_WRITE_SHARE) ? FILE_SHARE_WRITE : 0;
 
@@ -71,7 +71,7 @@ static bool BaseFile_Create(TFileStream * pStream)
     }
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
     {
         intptr_t handle;
 
@@ -95,7 +95,7 @@ static bool BaseFile_Create(TFileStream * pStream)
 
 static bool BaseFile_Open(TFileStream * pStream, LPCTSTR szFileName, DWORD dwStreamFlags)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     {
         ULARGE_INTEGER FileSize;
         DWORD dwWriteAccess = (dwStreamFlags & STREAM_FLAG_READ_ONLY) ? 0 : FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_WRITE_ATTRIBUTES;
@@ -121,7 +121,7 @@ static bool BaseFile_Open(TFileStream * pStream, LPCTSTR szFileName, DWORD dwStr
     }
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
     {
         struct stat64 fileinfo;
         int oflag = (dwStreamFlags & STREAM_FLAG_READ_ONLY) ? O_RDONLY : O_RDWR;
@@ -171,7 +171,7 @@ static bool BaseFile_Read(
     {
         ULONGLONG ByteOffset = GetByteOffset(pByteOffset, pStream->Base.File.FilePos);
 
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
         {
             // Note: We no longer support Windows 9x.
             // Thus, we can use the OVERLAPPED structure to specify
@@ -198,7 +198,7 @@ static bool BaseFile_Read(
         }
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
         {
             ssize_t bytes_read;
 
@@ -271,7 +271,7 @@ static bool BaseFile_Write(TFileStream * pStream, ULONGLONG * pByteOffset, const
     {
         ULONGLONG ByteOffset = GetByteOffset(pByteOffset, pStream->Base.File.FilePos);
 
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
         {
             // Note: We no longer support Windows 9x.
             // Thus, we can use the OVERLAPPED structure to specify
@@ -298,7 +298,7 @@ static bool BaseFile_Write(TFileStream * pStream, ULONGLONG * pByteOffset, const
         }
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
         {
             ssize_t bytes_written;
 
@@ -348,7 +348,7 @@ static bool BaseFile_Write(TFileStream * pStream, ULONGLONG * pByteOffset, const
  */
 static bool BaseFile_Resize(TFileStream * pStream, ULONGLONG NewFileSize)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     {
         LONG FileSizeHi = (LONG)(NewFileSize >> 32);
         LONG FileSizeLo;
@@ -373,7 +373,7 @@ static bool BaseFile_Resize(TFileStream * pStream, ULONGLONG NewFileSize)
     }
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
     {
         if(ftruncate64((intptr_t)pStream->Base.File.hFile, (off64_t)NewFileSize) == -1)
         {
@@ -408,12 +408,12 @@ static bool BaseFile_GetPos(TFileStream * pStream, ULONGLONG * pByteOffset)
 // Renames the file pointed by pStream so that it contains data from pNewStream
 static bool BaseFile_Replace(TFileStream * pStream, TFileStream * pNewStream)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     // Rename the new file to the old stream's file
     return (bool)MoveFileEx(pNewStream->szFileName, pStream->szFileName, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING);
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
     // "rename" on Linux also works if the target file exists
     if(rename(pNewStream->szFileName, pStream->szFileName) == -1)
     {
@@ -432,11 +432,11 @@ static void BaseFile_Close(TFileStream * pStream)
     {
         if(pStream->Base.File.hFile != INVALID_HANDLE_VALUE)
         {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
             CloseHandle(pStream->Base.File.hFile);
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
             close((intptr_t)pStream->Base.File.hFile);
 #endif
         }
@@ -465,7 +465,7 @@ static void BaseFile_Init(TFileStream * pStream)
 
 static bool BaseMap_Open(TFileStream * pStream, LPCTSTR szFileName, DWORD dwStreamFlags)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
 
     ULARGE_INTEGER FileSize;
     HANDLE hFile;
@@ -517,7 +517,7 @@ static bool BaseMap_Open(TFileStream * pStream, LPCTSTR szFileName, DWORD dwStre
         return false;
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
     struct stat64 fileinfo;
     intptr_t handle;
     bool bResult = false;
@@ -581,12 +581,12 @@ static bool BaseMap_Read(
 
 static void BaseMap_Close(TFileStream * pStream)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     if(pStream->Base.Map.pbFile != NULL)
         UnmapViewOfFile(pStream->Base.Map.pbFile);
 #endif
 
-#if defined(PLATFORM_MAC) || defined(PLATFORM_LINUX)
+#if defined(CASCLIB_PLATFORM_MAC) || defined(CASCLIB_PLATFORM_LINUX)
     if(pStream->Base.Map.pbFile != NULL)
         munmap(pStream->Base.Map.pbFile, (size_t )pStream->Base.Map.FileSize);
 #endif

--- a/src/common/Sockets.cpp
+++ b/src/common/Sockets.cpp
@@ -111,7 +111,7 @@ void CASC_SOCKET::Release()
 
 int CASC_SOCKET::GetSockError()
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     return WSAGetLastError();
 #else
     return errno;
@@ -134,7 +134,7 @@ DWORD CASC_SOCKET::GetAddrInfoWrapper(const char * hostName, unsigned portNum, P
         // Error-specific handling
         switch(dwErrCode)
         {
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
             case WSANOTINITIALISED:     // Windows-specific: WSAStartup not called
             {
                 WSADATA wsd;

--- a/test/CascTest.cpp
+++ b/test/CascTest.cpp
@@ -33,24 +33,24 @@
 #include <crtdbg.h>
 #endif
 
-#ifdef PLATFORM_LINUX
+#ifdef CASCLIB_PLATFORM_LINUX
 #include <dirent.h>
 #endif
 
 //------------------------------------------------------------------------------
 // Defines
 
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
 #define CASC_PATH_ROOT "/Multimedia/CASC"
 #define CASC_WORK_ROOT "/Multimedia/CASC/Work"
 #endif
 
-#ifdef PLATFORM_LINUX
+#ifdef CASCLIB_PLATFORM_LINUX
 #define CASC_PATH_ROOT "/media/ladik/CascStorages/CASC"
 #define CASC_WORK_ROOT "/home/ladik/CASC/Work"
 #endif
 
-#ifdef PLATFORM_MAC
+#ifdef CASCLIB_PLATFORM_MAC
 #define CASC_PATH_ROOT "/media/ladik/CascStorages"
 #define CASC_WORK_ROOT "/home/ladik/CASC/Work"  // TODO
 #endif
@@ -554,7 +554,7 @@ static void RunExtractWorkers(PCASC_FIND_DATA_ARRAY pFiles)
     std::vector<std::thread> threads;
     size_t dwCoresUsed = 10;
 
-#ifdef PLATFORM_WINDOWS
+#ifdef CASCLIB_PLATFORM_WINDOWS
     // Retrieve the number of available cores
     SYSTEM_INFO si = {0};
     DWORD dwFreeCPUs = 2;


### PR DESCRIPTION
* Prefix PLATFORM_ definitions with CASCLIB_ to avoid possible conflicts 
* Remove bzip2 references
* Only define __SYS_ZLIB if not defined earlier