### PR TITLE
Update Dll definitions

### DIFF
--- a/src/DllMain.def
+++ b/src/DllMain.def
@@ -33,5 +33,5 @@ EXPORTS
     CascFindEncryptionKey
     CascGetNotFoundEncryptionKey
 
-    GetLastError=Kernel32.GetLastError
-    SetLastError=Kernel32.SetLastError
+    GetCascError
+    SetCascError


### PR DESCRIPTION
CascLib started using its own GetError and SetError functions to preserve compatibility with platforms that don't define GetLastError and SetLastError, but this change was not reflected in the dll exports so linking of apps that use them fails. This PR fixes that (tested in vcpkg as master doesn't seem to use the def file anymore, vcpkg patches it back in).