### PR TITLE
Adding support for custom hosted CDN's 

### DIFF
--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -278,7 +278,6 @@ struct TCascStorage
     PCASC_OPEN_STORAGE_ARGS pArgs;                  // Open storage arguments. Only valid during opening the storage
     CASC_LOCK StorageLock;                          // Lock for multi-threaded operations
 
-
     LPCTSTR szIndexFormat;                          // Format of the index file name
     LPTSTR  szCdnHostUrl;                           // Cdn Host Url for online storage
     LPTSTR  szCdnHostRegion;                        // Cdn Host region prefix for online storage

--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -278,6 +278,7 @@ struct TCascStorage
     PCASC_OPEN_STORAGE_ARGS pArgs;                  // Open storage arguments. Only valid during opening the storage
     CASC_LOCK StorageLock;                          // Lock for multi-threaded operations
 
+    LPCTSTR szCdnHostUrl;                           // Cdn Host Url for online storage
     LPCTSTR szIndexFormat;                          // Format of the index file name
     LPTSTR  szCodeName;                             // On local storage, this select a product in a multi-product storage. For online storage, this selects a product
     LPTSTR  szRootPath;                             // Path where the build file is

--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -278,8 +278,9 @@ struct TCascStorage
     PCASC_OPEN_STORAGE_ARGS pArgs;                  // Open storage arguments. Only valid during opening the storage
     CASC_LOCK StorageLock;                          // Lock for multi-threaded operations
 
-    LPCTSTR szCdnHostUrl;                           // Cdn Host Url for online storage
+
     LPCTSTR szIndexFormat;                          // Format of the index file name
+    LPTSTR  szCdnHostUrl;                           // Cdn Host Url for online storage
     LPTSTR  szCodeName;                             // On local storage, this select a product in a multi-product storage. For online storage, this selects a product
     LPTSTR  szRootPath;                             // Path where the build file is
     LPTSTR  szDataPath;                             // This is the directory where data files are

--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -281,6 +281,7 @@ struct TCascStorage
 
     LPCTSTR szIndexFormat;                          // Format of the index file name
     LPTSTR  szCdnHostUrl;                           // Cdn Host Url for online storage
+    LPTSTR  szCdnHostRegion;                        // Cdn Host region prefix for online storage
     LPTSTR  szCodeName;                             // On local storage, this select a product in a multi-product storage. For online storage, this selects a product
     LPTSTR  szRootPath;                             // Path where the build file is
     LPTSTR  szDataPath;                             // This is the directory where data files are

--- a/src/CascDumpData.cpp
+++ b/src/CascDumpData.cpp
@@ -508,7 +508,8 @@ void CascDumpStorage(HANDLE hStorage, const char * szDumpFile)
         fprintf(fp, "IndexPath: %s\n", StringFromLPTSTR(hs->szIndexPath, szStringBuff, sizeof(szStringBuff)));
         fprintf(fp, "BuildFile: %s\n", StringFromLPTSTR(hs->szBuildFile, szStringBuff, sizeof(szStringBuff)));
         fprintf(fp, "CDN Server: %s\n", StringFromLPTSTR(hs->szCdnServers, szStringBuff, sizeof(szStringBuff)));
-        fprintf(fp, "CDN Path: %s\n", StringFromLPTSTR(hs->szCdnPath, szStringBuff, sizeof(szStringBuff)));
+        fprintf(fp, "CDN Host Url: %s\n", StringFromLPTSTR(hs->szCdnServers, szStringBuff, sizeof(szStringBuff)));
+        fprintf(fp, "CDN Path: %s\n", StringFromLPTSTR(hs->szCdnHostUrl, szStringBuff, sizeof(szStringBuff)));
         DumpKey(fp, "CDN Config Key: %s\n", hs->CdnConfigKey.pbData, hs->CdnConfigKey.cbData);
         DumpKey(fp, "CDN Build Key:  %s\n", hs->CdnBuildKey.pbData, hs->CdnBuildKey.cbData);
         DumpKey(fp, "Archives Key:   %s\n", hs->ArchivesKey.pbData, hs->ArchivesKey.cbData);

--- a/src/CascDumpData.cpp
+++ b/src/CascDumpData.cpp
@@ -509,6 +509,7 @@ void CascDumpStorage(HANDLE hStorage, const char * szDumpFile)
         fprintf(fp, "BuildFile: %s\n", StringFromLPTSTR(hs->szBuildFile, szStringBuff, sizeof(szStringBuff)));
         fprintf(fp, "CDN Server: %s\n", StringFromLPTSTR(hs->szCdnServers, szStringBuff, sizeof(szStringBuff)));
         fprintf(fp, "CDN Host Url: %s\n", StringFromLPTSTR(hs->szCdnHostUrl, szStringBuff, sizeof(szStringBuff)));
+        fprintf(fp, "CDN Host Region: %s\n", StringFromLPTSTR(hs->szCdnHostRegion, szStringBuff, sizeof(szStringBuff)));
         fprintf(fp, "CDN Path: %s\n", StringFromLPTSTR(hs->szCdnPath, szStringBuff, sizeof(szStringBuff)));
         DumpKey(fp, "CDN Config Key: %s\n", hs->CdnConfigKey.pbData, hs->CdnConfigKey.cbData);
         DumpKey(fp, "CDN Build Key:  %s\n", hs->CdnBuildKey.pbData, hs->CdnBuildKey.cbData);

--- a/src/CascDumpData.cpp
+++ b/src/CascDumpData.cpp
@@ -508,8 +508,8 @@ void CascDumpStorage(HANDLE hStorage, const char * szDumpFile)
         fprintf(fp, "IndexPath: %s\n", StringFromLPTSTR(hs->szIndexPath, szStringBuff, sizeof(szStringBuff)));
         fprintf(fp, "BuildFile: %s\n", StringFromLPTSTR(hs->szBuildFile, szStringBuff, sizeof(szStringBuff)));
         fprintf(fp, "CDN Server: %s\n", StringFromLPTSTR(hs->szCdnServers, szStringBuff, sizeof(szStringBuff)));
-        fprintf(fp, "CDN Host Url: %s\n", StringFromLPTSTR(hs->szCdnServers, szStringBuff, sizeof(szStringBuff)));
-        fprintf(fp, "CDN Path: %s\n", StringFromLPTSTR(hs->szCdnHostUrl, szStringBuff, sizeof(szStringBuff)));
+        fprintf(fp, "CDN Host Url: %s\n", StringFromLPTSTR(hs->szCdnHostUrl, szStringBuff, sizeof(szStringBuff)));
+        fprintf(fp, "CDN Path: %s\n", StringFromLPTSTR(hs->szCdnPath, szStringBuff, sizeof(szStringBuff)));
         DumpKey(fp, "CDN Config Key: %s\n", hs->CdnConfigKey.pbData, hs->CdnConfigKey.cbData);
         DumpKey(fp, "CDN Build Key:  %s\n", hs->CdnBuildKey.pbData, hs->CdnBuildKey.cbData);
         DumpKey(fp, "Archives Key:   %s\n", hs->ArchivesKey.pbData, hs->ArchivesKey.cbData);

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -1136,7 +1136,7 @@ static DWORD DownloadFile(
     return dwErrCode;
 }
 
-static DWORD RibbitDownloadFile(LPSTR szRegion, LPCTSTR szCdnHost, LPCTSTR szProduct, LPCTSTR szFileName, QUERY_KEY & FileData)
+static DWORD RibbitDownloadFile(LPCTSTR szCdnRegion, LPCTSTR szCdnHost, LPCTSTR szProduct, LPCTSTR szFileName, QUERY_KEY & FileData)
 {
     TFileStream * pStream;
     ULONGLONG FileSize = 0;
@@ -1145,7 +1145,7 @@ static DWORD RibbitDownloadFile(LPSTR szRegion, LPCTSTR szCdnHost, LPCTSTR szPro
 
     // Construct the full URL (https://wowdev.wiki/Ribbit)
     // Old (HTTP) download: wget http://us.patch.battle.net:1119/wow_classic/cdns
-    CascStrPrintf(szRemoteUrl, _countof(szRemoteUrl), szCdnHost, szRegion, szProduct, szFileName);
+    CascStrPrintf(szRemoteUrl, _countof(szRemoteUrl), szCdnHost, szCdnRegion, szProduct, szFileName);
 
     // Open the file stream
     if((pStream = FileStream_OpenFile(szRemoteUrl, 0)) != NULL)
@@ -1418,7 +1418,7 @@ DWORD LoadBuildInfo(TCascStorage * hs)
             return ERROR_CANCELLED;
 
         // Download the file using Ribbit protocol
-        dwErrCode = RibbitDownloadFile(hs->szRegion, hs->szCdnHostUrl, hs->szCodeName, _T("versions"), FileData);
+        dwErrCode = RibbitDownloadFile(hs->szCdnHostRegion, hs->szCdnHostUrl, hs->szCodeName, _T("versions"), FileData);
         if(dwErrCode == ERROR_SUCCESS)
         {
             // Parse the downloaded file
@@ -1447,7 +1447,7 @@ DWORD LoadCdnsFile(TCascStorage * hs)
         return ERROR_CANCELLED;
 
     // Download the file using Ribbit protocol
-    dwErrCode = RibbitDownloadFile(hs->szRegion, hs->szCdnHostUrl, hs->szCodeName, _T("cdns"), FileData);
+    dwErrCode = RibbitDownloadFile(hs->szCdnHostRegion, hs->szCdnHostUrl, hs->szCodeName, _T("cdns"), FileData);
     if(dwErrCode == ERROR_SUCCESS)
     {
         // Parse the downloaded file

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -1136,7 +1136,7 @@ static DWORD DownloadFile(
     return dwErrCode;
 }
 
-static DWORD RibbitDownloadFile(LPCTSTR szProduct, LPCTSTR szFileName, QUERY_KEY & FileData)
+static DWORD RibbitDownloadFile(LPCTSTR szCdnHost, LPCTSTR szProduct, LPCTSTR szFileName, QUERY_KEY & FileData)
 {
     TFileStream * pStream;
     ULONGLONG FileSize = 0;
@@ -1145,7 +1145,7 @@ static DWORD RibbitDownloadFile(LPCTSTR szProduct, LPCTSTR szFileName, QUERY_KEY
 
     // Construct the full URL (https://wowdev.wiki/Ribbit)
     // Old (HTTP) download: wget http://us.patch.battle.net:1119/wow_classic/cdns
-    CascStrPrintf(szRemoteUrl, _countof(szRemoteUrl), _T("ribbit://%s.version.battle.net/v1/products/%s/%s"), bnet_region, szProduct, szFileName);
+    CascStrPrintf(szRemoteUrl, _countof(szRemoteUrl), szCdnHost, bnet_region, szProduct, szFileName);
 
     // Open the file stream
     if((pStream = FileStream_OpenFile(szRemoteUrl, 0)) != NULL)
@@ -1418,7 +1418,7 @@ DWORD LoadBuildInfo(TCascStorage * hs)
             return ERROR_CANCELLED;
 
         // Download the file using Ribbit protocol
-        dwErrCode = RibbitDownloadFile(hs->szCodeName, _T("versions"), FileData);
+        dwErrCode = RibbitDownloadFile(hs->szCdnHostUrl, hs->szCodeName, _T("versions"), FileData);
         if(dwErrCode == ERROR_SUCCESS)
         {
             // Parse the downloaded file
@@ -1447,7 +1447,7 @@ DWORD LoadCdnsFile(TCascStorage * hs)
         return ERROR_CANCELLED;
 
     // Download the file using Ribbit protocol
-    dwErrCode = RibbitDownloadFile(hs->szCodeName, _T("cdns"), FileData);
+    dwErrCode = RibbitDownloadFile(hs->szCdnHostUrl, hs->szCodeName, _T("cdns"), FileData);
     if(dwErrCode == ERROR_SUCCESS)
     {
         // Parse the downloaded file

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -1136,7 +1136,7 @@ static DWORD DownloadFile(
     return dwErrCode;
 }
 
-static DWORD RibbitDownloadFile(LPCTSTR szCdnHost, LPCTSTR szProduct, LPCTSTR szFileName, QUERY_KEY & FileData)
+static DWORD RibbitDownloadFile(LPSTR szRegion, LPCTSTR szCdnHost, LPCTSTR szProduct, LPCTSTR szFileName, QUERY_KEY & FileData)
 {
     TFileStream * pStream;
     ULONGLONG FileSize = 0;
@@ -1145,7 +1145,7 @@ static DWORD RibbitDownloadFile(LPCTSTR szCdnHost, LPCTSTR szProduct, LPCTSTR sz
 
     // Construct the full URL (https://wowdev.wiki/Ribbit)
     // Old (HTTP) download: wget http://us.patch.battle.net:1119/wow_classic/cdns
-    CascStrPrintf(szRemoteUrl, _countof(szRemoteUrl), szCdnHost, bnet_region, szProduct, szFileName);
+    CascStrPrintf(szRemoteUrl, _countof(szRemoteUrl), szCdnHost, szRegion, szProduct, szFileName);
 
     // Open the file stream
     if((pStream = FileStream_OpenFile(szRemoteUrl, 0)) != NULL)
@@ -1418,7 +1418,7 @@ DWORD LoadBuildInfo(TCascStorage * hs)
             return ERROR_CANCELLED;
 
         // Download the file using Ribbit protocol
-        dwErrCode = RibbitDownloadFile(hs->szCdnHostUrl, hs->szCodeName, _T("versions"), FileData);
+        dwErrCode = RibbitDownloadFile(hs->szRegion, hs->szCdnHostUrl, hs->szCodeName, _T("versions"), FileData);
         if(dwErrCode == ERROR_SUCCESS)
         {
             // Parse the downloaded file
@@ -1447,7 +1447,7 @@ DWORD LoadCdnsFile(TCascStorage * hs)
         return ERROR_CANCELLED;
 
     // Download the file using Ribbit protocol
-    dwErrCode = RibbitDownloadFile(hs->szCdnHostUrl, hs->szCodeName, _T("cdns"), FileData);
+    dwErrCode = RibbitDownloadFile(hs->szRegion, hs->szCdnHostUrl, hs->szCodeName, _T("cdns"), FileData);
     if(dwErrCode == ERROR_SUCCESS)
     {
         // Parse the downloaded file

--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -317,6 +317,8 @@ typedef struct _CASC_OPEN_STORAGE_ARGS
     size_t Size;                                // Length of this structure. Initialize to sizeof(CASC_OPEN_STORAGE_ARGS)
 
     LPCTSTR szCdnHostUrl;                       // Online: Specify the cdn host url
+    LPCTSTR szCdnHostRegion;                    // Online: Specify the cdn host region
+
     LPCTSTR szLocalPath;                        // Local:  Path to the storage directory (where ".build.info: is) or any of the sub-path
                                                 // Online: Path to the local storage cache
 

--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -316,6 +316,7 @@ typedef struct _CASC_OPEN_STORAGE_ARGS
 {
     size_t Size;                                // Length of this structure. Initialize to sizeof(CASC_OPEN_STORAGE_ARGS)
 
+    LPCTSTR szCdnHostUrl;                       // Online: Specify the cdn host url
     LPCTSTR szLocalPath;                        // Local:  Path to the storage directory (where ".build.info: is) or any of the sub-path
                                                 // Online: Path to the local storage cache
 

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -101,7 +101,6 @@ TCascStorage::~TCascStorage()
     CascFreeLock(StorageLock);
 
     // Free the file paths
-    CASC_FREE(szCdnHostUrl);
     CASC_FREE(szDataPath);
     CASC_FREE(szRootPath);
     CASC_FREE(szBuildFile);

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -62,6 +62,7 @@ TCascStorage::TCascStorage()
     dwRefCount = 1;
 
     szRootPath = szDataPath = szIndexPath = szBuildFile = szCdnServers = szCdnPath = szCodeName = NULL;
+    szCdnHostUrl = NULL;
     szIndexFormat = NULL;
     szRegion = NULL;
     szBuildKey = NULL;
@@ -100,6 +101,7 @@ TCascStorage::~TCascStorage()
     CascFreeLock(StorageLock);
 
     // Free the file paths
+    CASC_FREE(szCdnHostUrl);
     CASC_FREE(szDataPath);
     CASC_FREE(szRootPath);
     CASC_FREE(szBuildFile);

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -61,7 +61,7 @@ TCascStorage::TCascStorage()
     pRootHandler = NULL;
     dwRefCount = 1;
 
-    szRootPath = szDataPath = szIndexPath = szBuildFile = szCdnServers = szCdnPath = szCdnHostUrl = szCodeName = NULL;
+    szRootPath = szDataPath = szIndexPath = szBuildFile = szCdnServers = szCdnPath = szCdnHostUrl = szCdnHostRegion = szCodeName = NULL;
     szIndexFormat = NULL;
     szRegion = NULL;
     szBuildKey = NULL;
@@ -108,6 +108,7 @@ TCascStorage::~TCascStorage()
     CASC_FREE(szCdnPath);
     CASC_FREE(szCodeName);
     CASC_FREE(szCdnHostUrl);
+    CASC_FREE(szCdnHostRegion);
     CASC_FREE(szRegion);
     CASC_FREE(szBuildKey);
 
@@ -1150,7 +1151,8 @@ static DWORD InitializeOnlineDirectories(TCascStorage * hs, PCASC_OPEN_STORAGE_A
 
 static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs)
 {
-    LPCTSTR szCdnHost = NULL;
+    LPCTSTR szCdnHostUrl = NULL;
+    LPCTSTR szCdnHostRegion = NULL;
     LPCTSTR szCodeName = NULL;
     LPCTSTR szRegion = NULL;
     LPCTSTR szBuildKey = NULL;
@@ -1164,8 +1166,12 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs)
     ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, dwLocaleMask), &dwLocaleMask);
 
     // Extract the product code name
-    if (ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCdnHostUrl), &szCdnHost) && szCdnHost != NULL)
-        hs->szCdnHostUrl = CascNewStr(szCdnHost);
+    if (ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCdnHostUrl), &szCdnHostUrl) && szCdnHostUrl != NULL)
+        hs->szCdnHostUrl = CascNewStr(szCdnHostUrl);
+
+    // Extract the product code name
+    if (ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCdnHostRegion), &szCdnHostRegion) && szCdnHostRegion != NULL)
+        hs->szCdnHostRegion = CascNewStr(szCdnHostRegion);
     
     // Extract the product code name
     if(ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCodeName), &szCodeName) && szCodeName != NULL)
@@ -1424,6 +1430,7 @@ bool WINAPI CascOpenOnlineStorage(LPCTSTR szParams, DWORD dwLocaleMask, HANDLE *
 
     OpenArgs.dwLocaleMask = dwLocaleMask;
     OpenArgs.szCdnHostUrl = _T("ribbit://%s.version.battle.net/v1/products/%s/%s");
+    OpenArgs.szCdnHostRegion = _T("us");
     return CascOpenStorageEx(szParams, &OpenArgs, true, phStorage);
 }
 

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -1165,11 +1165,11 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs)
     // Extract optional arguments
     ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, dwLocaleMask), &dwLocaleMask);
 
-    // Extract the product code name
+    // Extract the Cdn Hosr Url
     if (ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCdnHostUrl), &szCdnHostUrl) && szCdnHostUrl != NULL)
         hs->szCdnHostUrl = CascNewStr(szCdnHostUrl);
 
-    // Extract the product code name
+    // Extract the Cdn Hosr Region
     if (ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCdnHostRegion), &szCdnHostRegion) && szCdnHostRegion != NULL)
         hs->szCdnHostRegion = CascNewStr(szCdnHostRegion);
     

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -1149,6 +1149,7 @@ static DWORD InitializeOnlineDirectories(TCascStorage * hs, PCASC_OPEN_STORAGE_A
 
 static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs)
 {
+    LPCTSTR szCdnHost = NULL;
     LPCTSTR szCodeName = NULL;
     LPCTSTR szRegion = NULL;
     LPCTSTR szBuildKey = NULL;
@@ -1160,6 +1161,10 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs)
 
     // Extract optional arguments
     ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, dwLocaleMask), &dwLocaleMask);
+
+    // Extract the product code name
+    if (ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCdnHostUrl), &szCdnHost) && szCdnHost != NULL)
+        hs->szCdnHostUrl = CascNewStr(szCdnHost);
     
     // Extract the product code name
     if(ExtractVersionedArgument(pArgs, FIELD_OFFSET(CASC_OPEN_STORAGE_ARGS, szCodeName), &szCodeName) && szCodeName != NULL)
@@ -1289,7 +1294,7 @@ static LPTSTR ParseOpenParams(LPCTSTR szParams, PCASC_OPEN_STORAGE_ARGS pArgs)
     }
 
     // The 'pArgs' must be valid but must not contain 'szLocalPath', 'szCodeName' or 'szRegion'
-    if(pArgs->szLocalPath != NULL || pArgs->szCodeName != NULL || pArgs->szRegion != NULL)
+    if(pArgs->szCdnHostUrl != NULL || pArgs->szLocalPath != NULL || pArgs->szCodeName != NULL || pArgs->szRegion != NULL)
     {
         SetCascError(ERROR_INVALID_PARAMETER);
         return NULL;
@@ -1417,6 +1422,7 @@ bool WINAPI CascOpenOnlineStorage(LPCTSTR szParams, DWORD dwLocaleMask, HANDLE *
     CASC_OPEN_STORAGE_ARGS OpenArgs = {sizeof(CASC_OPEN_STORAGE_ARGS)};
 
     OpenArgs.dwLocaleMask = dwLocaleMask;
+    OpenArgs.szCdnHostUrl = _T("ribbit://%s.version.battle.net/v1/products/%s/%s");
     return CascOpenStorageEx(szParams, &OpenArgs, true, phStorage);
 }
 

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -61,8 +61,7 @@ TCascStorage::TCascStorage()
     pRootHandler = NULL;
     dwRefCount = 1;
 
-    szRootPath = szDataPath = szIndexPath = szBuildFile = szCdnServers = szCdnPath = szCodeName = NULL;
-    szCdnHostUrl = NULL;
+    szRootPath = szDataPath = szIndexPath = szBuildFile = szCdnServers = szCdnPath = szCdnHostUrl = szCodeName = NULL;
     szIndexFormat = NULL;
     szRegion = NULL;
     szBuildKey = NULL;
@@ -108,6 +107,7 @@ TCascStorage::~TCascStorage()
     CASC_FREE(szCdnServers);
     CASC_FREE(szCdnPath);
     CASC_FREE(szCodeName);
+    CASC_FREE(szCdnHostUrl);
     CASC_FREE(szRegion);
     CASC_FREE(szBuildKey);
 

--- a/src/common/FileStream.cpp
+++ b/src/common/FileStream.cpp
@@ -666,6 +666,7 @@ static DWORD BaseHttp_ParsePort(TFileStream* pStream, LPCTSTR szFileName, int& p
     {
         CascStrCopy(foundPort, 256, szPortPtr + 1, (szFilePtr - szPortPtr));
         port = atoi(foundPort);
+        CASC_FREE(foundPort);
 
         return ERROR_SUCCESS;
     }

--- a/src/common/Mime.cpp
+++ b/src/common/Mime.cpp
@@ -51,8 +51,11 @@ bool CASC_MIME_HTTP::IsDataComplete(const char * response, size_t response_lengt
             // Check if there's begin of the content
             if((content_begin_ptr = strstr(response, "\r\n\r\n")) != NULL)
             {
+                if ((content_length_ptr = strstr(response, "Content-Length: ")) == NULL)
+                    content_length_ptr = strstr(response, "content-length: ");
+
                 // HTTP responses contain "Content-Length: %u\n\r"
-                if((content_length_ptr = strstr(response, "Content-Length: ")) != NULL)
+                if(content_length_ptr != NULL)
                 {
                     // The content length info muse be before the actual content
                     if(content_length_ptr < content_begin_ptr)


### PR DESCRIPTION
CascLib currently only supports connection to existing blizzard CDN's. Within these commits I've added support for a custom connection URL to be supplied that will enable the ability to connect to privately hosted CDN's.

Summary of changes:
-Pushed the hardcoded ribbit/Http URL up so that It can now be passed in via arguments.
-Added support to parse the port from custom URL's as the port may differ from 80 for privately hosted CDN's.