### PR TITLE
Don't mix C and C++ memory allocations (part 2)

### DIFF
--- a/src/common/Csv.cpp
+++ b/src/common/Csv.cpp
@@ -231,7 +231,7 @@ DWORD CASC_CSV::Load(LPBYTE pbData, size_t cbData)
 {
     DWORD dwErrCode = ERROR_NOT_ENOUGH_MEMORY;
 
-    m_szCsvFile = new char[cbData + 1];
+    m_szCsvFile = CASC_ALLOC<char>(cbData + 1);
     if (m_szCsvFile != NULL)
     {
         // Copy the entire data and terminate them with zero


### PR DESCRIPTION
In c7a2b8ce75f52ddb450fec7bcfd3c760d2f9e0be I changed destruction of m_szCsvFile because of how it was allocated in LoadFileToMemory(), but I missed another allocation of it.