### PR TITLE
Extend FileDataId sanity check

### DIFF
--- a/src/common/FileTree.cpp
+++ b/src/common/FileTree.cpp
@@ -114,7 +114,7 @@ bool CASC_FILE_TREE::InsertToIdTable(PCASC_FILE_NODE pFileNode)
         if(FileDataId != CASC_INVALID_ID)
         {
             // Sanity check
-            assert(FileDataId < 0x10000000);
+            assert(FileDataId < CASC_INVALID_ID);
 
             // Insert the element to the array
             RefElement = (PCASC_FILE_NODE *)FileDataIds.InsertAt(FileDataId);


### PR DESCRIPTION
The FileDataId is a uint32 and can store data until 4294967295.