### PR TITLE
Skip setting CASC_FEATURE_ONLINE flag on storages opened locally from .build.info

### DIFF
--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -456,7 +456,7 @@ DWORD GetFileSpanInfo(PCASC_CKEY_ENTRY pCKeyEntry, PULONGLONG PtrContentSize, PU
 DWORD FetchCascFile(TCascStorage * hs, CPATH_TYPE PathType, LPBYTE pbEKey, LPCTSTR szExtension, CASC_PATH<TCHAR> & LocalPath, PCASC_ARCHIVE_INFO pArchiveInfo = NULL);
 DWORD CheckCascBuildFileExact(CASC_BUILD_FILE & BuildFile, LPCTSTR szLocalPath);
 DWORD CheckCascBuildFileDirs(CASC_BUILD_FILE & BuildFile, LPCTSTR szLocalPath);
-DWORD CheckOnlineStorage(PCASC_OPEN_STORAGE_ARGS pArgs, CASC_BUILD_FILE & BuildFile, DWORD dwFeatures);
+DWORD CheckOnlineStorage(PCASC_OPEN_STORAGE_ARGS pArgs, CASC_BUILD_FILE & BuildFile);
 DWORD CheckArchiveFilesDirectories(TCascStorage * hs);
 DWORD CheckDataFilesDirectory(TCascStorage * hs);
 DWORD LoadMainFile(TCascStorage * hs);

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -1539,10 +1539,10 @@ DWORD CheckCascBuildFileDirs(CASC_BUILD_FILE & BuildFile, LPCTSTR szLocalPath)
     return dwErrCode;
 }
 
-DWORD CheckOnlineStorage(PCASC_OPEN_STORAGE_ARGS pArgs, CASC_BUILD_FILE & BuildFile, DWORD dwFeatures)
+DWORD CheckOnlineStorage(PCASC_OPEN_STORAGE_ARGS pArgs, CASC_BUILD_FILE & BuildFile)
 {
     // If the online storage is required, we try to extract the product code
-    if((dwFeatures & CASC_FEATURE_ONLINE) && (pArgs->szCodeName != NULL))
+    if(pArgs->szCodeName != NULL)
     {
         CASC_PATH<TCHAR> FilePath(pArgs->szLocalPath, _T("versions"), NULL);
 

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -1390,7 +1390,7 @@ bool WINAPI CascOpenStorageEx(LPCTSTR szParams, PCASC_OPEN_STORAGE_ARGS pArgs, b
         if((hs = new TCascStorage()) != NULL)
         {
             CASC_BUILD_FILE BuildFile = {NULL};
-            DWORD dwFeatures = bOnlineStorage ? CASC_FEATURE_ONLINE : 0;
+            DWORD dwFeatures = 0;
             
             // Check for one of the supported main files (.build.info, .build.db, versions)
             if((dwErrCode = CheckCascBuildFileExact(BuildFile, pArgs->szLocalPath)) == ERROR_SUCCESS)
@@ -1405,9 +1405,9 @@ bool WINAPI CascOpenStorageEx(LPCTSTR szParams, PCASC_OPEN_STORAGE_ARGS pArgs, b
             }
 
             // If the caller requested an online storage, we must have the code name
-            else if((dwErrCode = CheckOnlineStorage(pArgs, BuildFile, dwFeatures)) == ERROR_SUCCESS)
+            else if(bOnlineStorage && (dwErrCode = CheckOnlineStorage(pArgs, BuildFile)) == ERROR_SUCCESS)
             {
-                dwErrCode = LoadCascStorage(hs, pArgs, BuildFile.szFullPath, BuildFile.BuildFileType, dwFeatures | CASC_FEATURE_DATA_FILES);
+                dwErrCode = LoadCascStorage(hs, pArgs, BuildFile.szFullPath, BuildFile.BuildFileType, dwFeatures | CASC_FEATURE_DATA_FILES | CASC_FEATURE_ONLINE);
             }
         }
     }


### PR DESCRIPTION
This will change two things
* CascLib will no longer try to fetch files from cdn when storage was opened with a local config (.build.info)
* library users will be able to detect if opened mode was different than what they requested, using `CascGetStorageInfo(storage, CascStorageFeatures, ...)`
