### PR TITLE
Replace usages of predefined macro _DEBUG with CASCLIB_DEBUG

### DIFF
--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -21,6 +21,10 @@
     #include <zlib.h>
 #endif
 
+#if defined(_DEBUG) && !defined(CASCLIB_NODEBUG)
+#define CASCLIB_DEBUG
+#endif
+
 #include "CascPort.h"
 #include "common/Common.h"
 #include "common/Array.h"
@@ -48,7 +52,7 @@
 //-----------------------------------------------------------------------------
 // CascLib private defines
 
-#if defined(_DEBUG) && defined(CASCLIB_DEV)
+#if defined(CASCLIB_DEBUG) && defined(CASCLIB_DEV)
 #define BREAK_ON_XKEY3(CKey, v0, v1, v2) if(CKey[0] == v0 && CKey[1] == v1 && CKey[2] == v2) { __debugbreak(); }
 #define BREAKIF(condition)               if(condition)  { __debugbreak(); }
 #else
@@ -506,7 +510,7 @@ DWORD RootHandler_CreateInstall(TCascStorage * hs, CASC_BLOB & InstallFile);
 //-----------------------------------------------------------------------------
 // Dumpers (CascDumpData.cpp)
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
 void CascDumpData(LPCSTR szFileName, const void * pvData, size_t cbData);
 void CascDumpFile(HANDLE hFile, const char * szDumpFile = NULL);
 void CascDumpStorage(HANDLE hStorage, const char * szDumpFile = NULL);

--- a/src/CascDumpData.cpp
+++ b/src/CascDumpData.cpp
@@ -12,7 +12,7 @@
 #include "CascLib.h"
 #include "CascCommon.h"
 
-#ifdef _DEBUG       // The entire feature is only valid for debug purposes
+#ifdef CASCLIB_DEBUG       // The entire feature is only valid for debug purposes
 
 //-----------------------------------------------------------------------------
 // Forward definitions
@@ -78,7 +78,7 @@ static void DumpKey(FILE * fp, const char * szInFormat, LPBYTE pbData, size_t cb
         // If there will be more lines, then we clear the entire part until "%s"
         if(szFormatSpec != NULL)
             memset(szFormat, ' ', (szFormatSpec - szFormat));
-        
+
         // Move pointers
         pbData += MD5_HASH_SIZE;
     }
@@ -541,9 +541,9 @@ void CascDumpStorage(HANDLE hStorage, const char * szDumpFile)
     }
 }
 
-#else // _DEBUG
+#else // CASCLIB_DEBUG
 
 // so linker won't mind this .cpp file is empty in non-DEBUG builds
 void unused_symbol() { }
 
-#endif // _DEBUG
+#endif // CASCLIB_DEBUG

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -29,7 +29,7 @@
 
 #define CHECKED_KEY {0x00, 0x00, 0x0F, 0x84}
 
-#if defined(_DEBUG) && defined(CHECKED_KEY)
+#if defined(CASCLIB_DEBUG) && defined(CHECKED_KEY)
 
 inline bool CheckForXKey(LPBYTE XKey)
 {
@@ -117,7 +117,7 @@ TCascStorage::~TCascStorage()
     // Free the blobs
     FreeCascBlob(&CdnConfigKey);
     FreeCascBlob(&CdnBuildKey);
-    
+
     FreeCascBlob(&ArchiveGroup);
     FreeCascBlob(&ArchivesKey);
     FreeCascBlob(&PatchArchivesKey);
@@ -423,8 +423,8 @@ static int LoadEncodingCKeyPage(TCascStorage * hs, CASC_ENCODING_HEADER & EnHead
         if(pFileEntry->EKeyCount == 0)
             break;
 
-        // Example of a file entry with multiple EKeys: 
-        // Overwatch build 24919, CKey: 0e 90 94 fa d2 cb 85 ac d0 7c ea 09 f9 c5 ba 00 
+        // Example of a file entry with multiple EKeys:
+        // Overwatch build 24919, CKey: 0e 90 94 fa d2 cb 85 ac d0 7c ea 09 f9 c5 ba 00
 //      BREAKIF(pFileEntry->EKeyCount > 1);
 //      BREAK_ON_XKEY3(pFileEntry->CKey, 0x34, 0x82, 0x1f);
 
@@ -613,7 +613,7 @@ int CaptureDownloadTag(CASC_DOWNLOAD_HEADER & DlHeader, CASC_TAG_ENTRY1 & DlTag,
         pbFilePtr++;
     if(pbFilePtr >= pbFileEnd)
         return ERROR_BAD_FORMAT;
-    
+
     // Save the length of the tag name
     DlTag.NameLength = (pbFilePtr - pbSaveFilePtr);
     pbFilePtr++;
@@ -630,7 +630,7 @@ int CaptureDownloadTag(CASC_DOWNLOAD_HEADER & DlHeader, CASC_TAG_ENTRY1 & DlTag,
     // Get the bitmap length.
     // If the bitmap is last in the list and it's shorter than declared, we make it shorter
     DlTag.BitmapLength = GetTagBitmapLength(pbFilePtr, pbFileEnd, DlHeader.EntryCount);
-    
+
     // Get the entry length
     DlTag.TagLength = (pbFilePtr - pbSaveFilePtr) + DlTag.BitmapLength;
     return ERROR_SUCCESS;
@@ -769,7 +769,7 @@ static int LoadDownloadManifest(TCascStorage * hs)
         if(dwErrCode == ERROR_SUCCESS)
         {
             // Parse the entire download manifest
-            dwErrCode = LoadDownloadManifest(hs, DlHeader, DownloadFile.pbData, DownloadFile.pbData + DownloadFile.cbData); 
+            dwErrCode = LoadDownloadManifest(hs, DlHeader, DownloadFile.pbData, DownloadFile.pbData + DownloadFile.cbData);
         }
     }
 
@@ -1391,7 +1391,7 @@ bool WINAPI CascOpenStorageEx(LPCTSTR szParams, PCASC_OPEN_STORAGE_ARGS pArgs, b
         if((hs = new TCascStorage()) != NULL)
         {
             CASC_BUILD_FILE BuildFile = {NULL};
-            
+
             // Check for one of the supported main files (.build.info, .build.db, versions)
             if((dwErrCode = CheckCascBuildFileExact(BuildFile, pArgs->szLocalPath)) == ERROR_SUCCESS)
             {
@@ -1426,7 +1426,7 @@ bool WINAPI CascOpenStorageEx(LPCTSTR szParams, PCASC_OPEN_STORAGE_ARGS pArgs, b
 }
 
 //
-// Opens a local CASC storage 
+// Opens a local CASC storage
 //
 // szParams: "local_path:code_name", like "C:\\Games\\World of Warcraft:wowt"
 //

--- a/src/CascReadFile.cpp
+++ b/src/CascReadFile.cpp
@@ -116,7 +116,7 @@ static DWORD OpenDataStream(TCascFile * hf, PCASC_FILE_SPAN pFileSpan, PCASC_CKE
     }
 }
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
 static unsigned int table_16C57A8[0x10] =
 {
     0x049396B8, 0x72A82A9B, 0xEE626CCA, 0x9917754F,
@@ -182,7 +182,7 @@ static DWORD ParseBlteHeader(PCASC_FILE_SPAN pFileSpan, PCASC_CKEY_ENTRY pCKeyEn
         if(pEncodedHeader->EncodedSize != pCKeyEntry->EncodedSize)
             return ERROR_BAD_FORMAT;
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
         // Not really needed, it's here just for explanation of what the values mean
         //assert(memcmp(pCKeyEntry->EKey, pEncodedHeader->EKey.Value, MD5_HASH_SIZE) == 0);
         VerifyHeaderSpan(pEncodedHeader, HeaderOffset);
@@ -203,7 +203,7 @@ static DWORD ParseBlteHeader(PCASC_FILE_SPAN pFileSpan, PCASC_CKEY_ENTRY pCKeyEn
     {
         if(pBlteHeader->MustBe0F != 0x0F)
             return ERROR_BAD_FORMAT;
-        
+
         // Verify the header size
         FrameCount = ConvertBytesToInteger_3(pBlteHeader->FrameCount);
         ExpectedHeaderSize = 0x0C + FrameCount * sizeof(BLTE_FRAME);
@@ -587,7 +587,7 @@ static DWORD DecodeFileFrame(
         switch(pbEncoded[0])
         {
             case 'E':   // Encrypted files
-                
+
                 // The work buffer should not have been allocated by any step
                 assert(pbWorkBuffer == NULL && cbWorkBuffer == 0);
 
@@ -613,7 +613,7 @@ static DWORD DecodeFileFrame(
                 break;
 
             case 'Z':   // ZLIB compressed files
-                
+
                 // If we decompressed less than expected, we simply fill the rest with zeros
                 // Example: INSTALL file from the TACT CASC storage
                 cbDecodedExpected = cbDecoded;
@@ -784,7 +784,7 @@ static DWORD ReadFile_WholeFile(TCascFile * hf, LPBYTE pbBuffer)
         ULONGLONG ByteOffset = pFileSpan->ArchiveOffs + pFileSpan->HeaderSize;
         DWORD EncodedSize = pCKeyEntry->EncodedSize - pFileSpan->HeaderSize;
 
-        // Allocate the buffer for the entire encoded span 
+        // Allocate the buffer for the entire encoded span
         pbEncodedPtr = pbEncoded = CASC_ALLOC<BYTE>(EncodedSize);
         if(pbEncoded == NULL)
         {
@@ -1054,7 +1054,7 @@ bool WINAPI CascSetFileFlags(HANDLE hFile, DWORD dwOpenFlags)
 // HotS(29049)  ENCODING  0x0024BA45 - 0x0024b98a  0x0024BA45  n/a         0x0024BA45  n/a
 // HotS(29049)  ROOT      0x00193340 - 0x00193340  0x0010db65  0x00193340  0x0010db65  n/a
 // HotS(29049)  (other)   0x00001080 - 0x00001080  0x000008eb  0x00001080  0x000008eb  0x00001080
-//                                                             
+//
 // WoW(18888)   ENCODING  0x030d487b - 0x030dee79  0x030d487b  n/a         0x030d487b  n/a
 // WoW(18888)   ROOT      0x016a9800 - n/a         0x0131313d  0x016a9800  0x0131313d  n/a
 // WoW(18888)   (other)   0x000007d0 - 0x000007d0  0x00000397  0x000007d0  0x00000397  n/a
@@ -1187,7 +1187,7 @@ DWORD WINAPI CascSetFilePointer(HANDLE hFile, LONG lFilePos, LONG * PtrFilePosHi
 {
     ULONGLONG NewPos = 0;
     LONGLONG DistanceToMove;
-    
+
     // Assemble the 64-bit distance to move
     DistanceToMove = (PtrFilePosHigh != NULL) ? MAKE_OFFSET64(PtrFilePosHigh[0], lFilePos) : (LONGLONG)(LONG)lFilePos;
 
@@ -1279,7 +1279,7 @@ bool WINAPI CascReadFile(HANDLE hFile, void * pvBuffer, DWORD dwBytesToRead, PDW
     {
         // No caching at all. The entire file will be read directly to the user buffer
         // Used for loading internal files, where we need to read the whole file
-        case CascCacheNothing:  
+        case CascCacheNothing:
             dwBytesRead2 = ReadFile_NonCached(hf, pbBuffer, StartOffset, EndOffset);
             break;
 
@@ -1305,7 +1305,7 @@ bool WINAPI CascReadFile(HANDLE hFile, void * pvBuffer, DWORD dwBytesToRead, PDW
         if(PtrBytesRead != NULL)
             PtrBytesRead[0] = 0;
         hf->FilePointer = SaveFilePointer;
-        
+
         // If 0 bytes were requested, it's actually a success
         return (dwBytesToRead == 0);
     }

--- a/src/CascRootFile_MNDX.cpp
+++ b/src/CascRootFile_MNDX.cpp
@@ -660,7 +660,7 @@ class TBitEntryArray : public TGenericArray<DWORD>
 #define INDEX_TO_GROUP(val)   (val >> 9)
 #define GROUP_TO_INDEX(grp)   (grp << 9)
 
-// For each 0x200-th bit, this contains information about amount of "1" bits 
+// For each 0x200-th bit, this contains information about amount of "1" bits
 typedef struct _BASEVALS
 {
     DWORD BaseValue200;             // Item value of every 0x200-th item
@@ -791,7 +791,7 @@ class TSparseArray
         if(index & 0x20)
             IntValue += GetNumberOfSetBits32(ItemBits[(index >> 0x05) - 1]);
 
-        // 4) Count the bits in the current DWORD (masked by bit index mask) 
+        // 4) Count the bits in the current DWORD (masked by bit index mask)
         BitMask = (1 << (index & 0x1F)) - 1;
         return IntValue + GetNumberOfSetBits32(ItemBits[index >> 0x05] & BitMask);
     }
@@ -888,7 +888,7 @@ class TSparseArray
         DWORD bitGroup;
         DWORD edx = index;
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
         //if(TotalItemCount > 0x200)
         //{
         //    FILE * fp = fopen("e:\\Ladik\\Appdir\\CascLib\\doc\\mndx-sparse-array.txt", "wt");
@@ -1177,7 +1177,7 @@ class TSparseArray
         return table_1BA1818[bitGroup + distFromBase] + itemIndex;
     }
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
     void Dump(FILE * fp)
     {
         size_t * ArrayNormal;
@@ -1868,7 +1868,7 @@ class TFileNameDatabase
             // Get the hasn table item
             pHashEntry = &HashTable[TableIndex & HashTableMask];
 
-            // 
+            //
             if(TableIndex == pHashEntry->NextIndex)
             {
                 // HOTS: 01957BB4
@@ -2467,7 +2467,7 @@ class TFileNameDatabase
 
     TSparseArray CollisionTable;                // Table of valid collisions, indexed by NodeIndex
     TSparseArray FileNameIndexes;               // Array of file name indexes
-    TSparseArray CollisionHiBitsIndexes;        // Table of indexes of high bits (above 8 bits) for collisions 
+    TSparseArray CollisionHiBitsIndexes;        // Table of indexes of high bits (above 8 bits) for collisions
 
     // This pair of arrays serves for fast conversion from node index to FragmentOffset / FragmentChar
     TGenericArray<BYTE> LoBitsTable;            // Array of lower 8 bits of name fragment offset

--- a/src/CascRootFile_WoW.cpp
+++ b/src/CascRootFile_WoW.cpp
@@ -81,7 +81,7 @@ typedef struct _FILE_ROOT_GROUP
 //-----------------------------------------------------------------------------
 // Debug local stuff
 
-#if defined(_MSC_VER) && defined(_DEBUG)
+#if defined(_MSC_VER) && defined(CASCLIB_DEBUG)
 static FILE * fp = NULL;
 static bool bLogEntries = true;
 
@@ -114,7 +114,7 @@ struct TRootHandler_WoW : public TFileTreeRoot
 
     TRootHandler_WoW(ROOT_FORMAT RFormat, DWORD HashlessFileCount) : TFileTreeRoot(FTREE_FLAGS_WOW)
     {
-        // Turn off the "we know file names" bit 
+        // Turn off the "we know file names" bit
         FileCounterHashless = HashlessFileCount;
         FileCounter = 0;
         RootFormat = RFormat;
@@ -180,7 +180,7 @@ struct TRootHandler_WoW : public TFileTreeRoot
                 return pbRootPtr + (sizeof(FILE_ROOT_ENTRY) * RootGroup.Header.NumberOfFiles);
 
             case RootFormatWoW82:
-                
+
                 // Verify the position of array of CONTENT_KEY
                 if((pbRootPtr + (sizeof(CONTENT_KEY) * RootGroup.Header.NumberOfFiles)) > pbRootEnd)
                     return NULL;
@@ -254,12 +254,6 @@ struct TRootHandler_WoW : public TFileTreeRoot
         {
             // Set the file data ID
             FileDataId = FileDataId + RootGroup.FileDataIds[i];
-            
-#if defined(_MSC_VER) && defined(_DEBUG)
-            if(FileDataId == 3314016)
-                __debugbreak();
-            LogEntry(FileDataId, pCKey);
-#endif
 
             // Find the item in the central storage. Insert it to the tree
             if((pCKeyEntry = FindCKeyEntry_CKey(hs, pCKey->Value)) != NULL)
@@ -387,7 +381,7 @@ struct TRootHandler_WoW : public TFileTreeRoot
     */
 
     DWORD ParseWowRootFile_Level1(
-        TCascStorage * hs, 
+        TCascStorage * hs,
         LPBYTE pbRootPtr,
         LPBYTE pbRootEnd,
         DWORD dwLocaleMask,
@@ -419,7 +413,7 @@ struct TRootHandler_WoW : public TFileTreeRoot
         if(dwErrCode == ERROR_SUCCESS)
             dwErrCode = ParseWowRootFile_Level1(hs, pbRootPtr, pbRootEnd, dwLocaleMask, 1);
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
         // Dump the array of the file data IDs
         //FileTree.DumpFileDataIds("e:\\file-data-ids.bin");
 #endif

--- a/src/common/Array.h
+++ b/src/common/Array.h
@@ -104,7 +104,7 @@ class CASC_ARRAY
         // Make sure we have array large enough
         if(!EnlargeArray(ItemIndex + 1, true))
             return NULL;
-        
+
         // Get the items range
         pbLastItem = m_pItemArray + (m_ItemCount * m_ItemSize);
         pbNewItem = m_pItemArray + (ItemIndex * m_ItemSize);
@@ -170,7 +170,7 @@ class CASC_ARRAY
         m_ItemCountMax = m_ItemCount = m_ItemSize = 0;
     }
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
     size_t BytesAllocated()
     {
         return m_ItemCountMax * m_ItemSize;

--- a/src/common/ArraySparse.h
+++ b/src/common/ArraySparse.h
@@ -229,7 +229,7 @@ class CASC_SPARSE_ARRAY
         return (m_pLevel0 != NULL);
     }
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
     size_t BytesAllocated()
     {
         return m_LevelsAllocated * sizeof(CASC_ARRAY_256);

--- a/src/common/FileTree.h
+++ b/src/common/FileTree.h
@@ -82,7 +82,7 @@ class CASC_FILE_TREE
     // Retrieve the maximum FileDataId ever inserted
     DWORD GetNextFileDataId();
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
     void DumpFileDataIds(const char * szFileName)
     {
         FileDataIds.Dump(szFileName);

--- a/src/common/Mime.cpp
+++ b/src/common/Mime.cpp
@@ -331,7 +331,7 @@ DWORD CASC_MIME_ELEMENT::Load(char * mime_data_begin, char * mime_data_end, cons
             // Otherwise, we decode the data to the end of the document
             if(boundary_ptr != NULL)
             {
-                // Find the end of the current data by the boundary. It is 2 characters before the next boundary 
+                // Find the end of the current data by the boundary. It is 2 characters before the next boundary
                 content.end = strstr(content.ptr, boundary_ptr);
                 if(content.end == NULL)
                     return ERROR_BAD_FORMAT;
@@ -362,7 +362,7 @@ DWORD CASC_MIME_ELEMENT::Load(char * mime_data_begin, char * mime_data_end, cons
                 case MimeEncodingBase64:
                     dwErrCode = DecodeBase64(content.ptr, content.end, data);
                     break;
-                    
+
                 default:
                     dwErrCode = ERROR_NOT_SUPPORTED;
                     assert(false);
@@ -379,7 +379,7 @@ DWORD CASC_MIME_ELEMENT::Load(char * mime_data_begin, char * mime_data_end, cons
     return dwErrCode;
 }
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
 #define MAX_LEVEL 0x10
 void CASC_MIME_ELEMENT::Print(size_t nLevel, size_t nIndex)
 {
@@ -473,7 +473,7 @@ bool CASC_MIME_ELEMENT::ExtractBoundary(const char * line)
     {
         // Set begin of the boundary
         begin = begin + 10;
-        
+
         // Is there also end?
         if((end = strchr(begin, '\"')) != NULL)
         {
@@ -647,7 +647,7 @@ DWORD CASC_MIME::Load(char * data, CASC_MIME_RESPONSE & MimeResponse)
         return ERROR_BAD_FORMAT;
 
     // Debug: dump the MIME data to file
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
     //CascDumpData("E:\\mime_raw_data.txt", data, MimeResponse.response_length);
 #endif
 
@@ -667,7 +667,7 @@ DWORD CASC_MIME::Load(char * data, CASC_MIME_RESPONSE & MimeResponse)
     return root.Load(data, data + MimeResponse.response_length);
 }
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
 void CASC_MIME::Print()
 {
     root.Print(0, 0);

--- a/src/common/Mime.h
+++ b/src/common/Mime.h
@@ -92,7 +92,7 @@ class CASC_MIME_ELEMENT
 
     CASC_MIME_ELEMENT * GetChild()  { return folder.pChild; }
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
     void Print(size_t nLevel, size_t nIndex);
 #endif
 
@@ -127,7 +127,7 @@ class CASC_MIME
 
     DWORD Load(char * data, CASC_MIME_RESPONSE & MimeResponse);
 
-#ifdef _DEBUG
+#ifdef CASCLIB_DEBUG
     void Print();
 #endif
 


### PR DESCRIPTION
Some of this debug code makes casclib unusable by other projects when compiled in debug mode (__debugbreak() on specific fileid)

My code uses cmake to generate all project files so if i want to build my code in debug mode, casclib also has to be built in debug mode (even if that wasnt a requirement, mixing debug and release CRT is not a good idea)

Because _DEBUG cannot be undefined (its enforced when compiling with debug CRT), this PR replaces its usage with a new macro that can be undefined by users