### PR TITLE
Fix linux build

### DIFF
--- a/src/CascReadFile.cpp
+++ b/src/CascReadFile.cpp
@@ -1039,7 +1039,7 @@ bool WINAPI CascSetFileFlags(HANDLE hFile, DWORD dwOpenFlags)
     }
 
     // Set "overcome encrypted" flag. Will apply on next CascReadFile
-    hf->bOvercomeEncrypted = (dwOpenFlags & CASC_OVERCOME_ENCRYPTED) ? TRUE : FALSE;
+    hf->bOvercomeEncrypted = (dwOpenFlags & CASC_OVERCOME_ENCRYPTED) != 0;
     return true;
 }
 


### PR DESCRIPTION
```
/mnt/c/Users/shaur/Desktop/Sources/TrinityCore/dep/CascLib/src/CascReadFile.cpp:1042:72: error: use of undeclared identifier 'TRUE'
    hf->bOvercomeEncrypted = (dwOpenFlags & CASC_OVERCOME_ENCRYPTED) ? TRUE : FALSE;
                                                                       ^
```