### PR TITLE
Increase pre-allocated Casc table sizes to address crashing

### DIFF
--- a/src/CascRootFile_TVFS.cpp
+++ b/src/CascRootFile_TVFS.cpp
@@ -712,7 +712,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         FileTree.SetKeyLength(RootHeader.EKeySize);
 
         // Initialize the array of span entries
-        dwErrCode = SpanArray.Create(sizeof(CASC_CKEY_ENTRY), 0x100);
+        dwErrCode = SpanArray.Create(sizeof(CASC_CKEY_ENTRY), 0x10000);
         if(dwErrCode != ERROR_SUCCESS)
             return dwErrCode;
 

--- a/src/CascStructs.h
+++ b/src/CascStructs.h
@@ -17,7 +17,7 @@
 #define CASC_INDEX_COUNT          0x10              // Number of index files
 #define CASC_CKEY_SIZE            0x10              // Size of the content key
 #define CASC_EKEY_SIZE            0x09              // Size of the encoded key
-#define CASC_MAX_DATA_FILES      0x100              // Maximum number of data files
+#define CASC_MAX_DATA_FILES       0x1000            // Maximum number of data files
 
 //-----------------------------------------------------------------------------
 // The index files structures


### PR DESCRIPTION
This part of the change comes from [Scobalula](https://github.com/Scobalula).
I submitted it on his behalf.

Problem:

Basically when casc patches certain installations, it creates more than 256 data files.
It's why certain people experienced crashes when this happens.

As for the span array, He experienced this during the beta of Bocw and so many others did, span array goes above 256 and casclib doesn't check and just blindly reallocated the array.

[test.txt](https://github.com/ladislav-zezula/CascLib/files/13775736/test.txt)
This can happen during a heavily patched installation and when battlenet says "playable" while still updating.

In Call of Duty, it can be as (.xsub/.xpak) files are all over the place with potentially >1GB file size so multiple file spans.