### PR TITLE
* Enhanced file caching and handling in CASC library

### DIFF
--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -92,6 +92,7 @@ typedef enum _CSTRTG
     CascCacheInvalid,                               // Do not cache anything. Used as invalid value
     CascCacheNothing,                               // Do not cache anything. Used on internal files, where the content is loaded directly to the user buffer
     CascCacheLastFrame,                             // Only cache one file frame
+    CascCacheWholeFile,                             // cache whole file
 } CSTRTG, *PCSTRTG;
 
 // Tag file entry, loaded from the DOWNLOAD file

--- a/src/CascLib.h
+++ b/src/CascLib.h
@@ -90,6 +90,7 @@ extern "C" {
 #define CASC_OVERCOME_ENCRYPTED     0x00000020  // When CascReadFile encounters a block encrypted with a key that is missing, the block is filled with zeros and returned as success
 #define CASC_OPEN_CKEY_ONCE         0x00000040  // Only opens a file with given CKey once, regardless on how many file names does it have. Used by CascLib test program
                                                 // If the file was already open before, CascOpenFile returns false and ERROR_FILE_ALREADY_OPENED
+#define CASC_CACHE_WHOLE_FILE       0x00000080  //
 
 #define CASC_LOCALE_ALL             0xFFFFFFFF
 #define CASC_LOCALE_ALL_WOW         0x0001F3F6  // All except enCN and enTW
@@ -389,6 +390,8 @@ bool   WINAPI CascGetFileSize64(HANDLE hFile, PULONGLONG PtrFileSize);
 bool   WINAPI CascSetFilePointer64(HANDLE hFile, LONGLONG DistanceToMove, PULONGLONG PtrNewPos, DWORD dwMoveMethod);
 bool   WINAPI CascReadFile(HANDLE hFile, void * lpBuffer, DWORD dwToRead, PDWORD pdwRead);
 bool   WINAPI CascCloseFile(HANDLE hFile);
+bool   WINAPI CascSetCacheStrategy(HANDLE hFile, bool bWholeFileCache);
+DWORD  WINAPI CascGetFileId(HANDLE hStorage, LPCSTR szFileName);
 
 DWORD  WINAPI CascGetFileSize(HANDLE hFile, PDWORD pdwFileSizeHigh);
 DWORD  WINAPI CascSetFilePointer(HANDLE hFile, LONG lFilePos, LONG * PtrFilePosHigh, DWORD dwMoveMethod);

--- a/src/CascRootFile_OW.cpp
+++ b/src/CascRootFile_OW.cpp
@@ -353,11 +353,11 @@ struct TRootHandler_OW : public TFileTreeRoot
                     // Check for content manifest files
                     if(!_stricmp(szExtension, ".cmf"))
                     {
-                        dwErrCode = LoadContentManifestFile(hs, FileTree, pFileNode->pCKeyEntry, szFileName);
+                        dwErrCode = LoadContentManifestFile(hs, FileTree, pFileNode->pCKeyEntry[0], szFileName);
                     }
                     else if(!_stricmp(szExtension, ".apm"))
                     {
-                        dwErrCode = LoadApplicationPackageManifestFile(hs, FileTree, pFileNode->pCKeyEntry, szFileName);
+                        dwErrCode = LoadApplicationPackageManifestFile(hs, FileTree, pFileNode->pCKeyEntry[0], szFileName);
                     }
                 }
             }

--- a/src/common/FileTree.h
+++ b/src/common/FileTree.h
@@ -25,7 +25,10 @@
 typedef struct _CASC_FILE_NODE
 {
     ULONGLONG FileNameHash;                         // Jenkins hash of the normalized file name (uppercase, backslashes)
-    PCASC_CKEY_ENTRY pCKeyEntry;                    // Pointer to the CKey entry
+    //PCASC_CKEY_ENTRY pCKeyEntry;                  // Pointer to the CKey entry
+    PCASC_CKEY_ENTRY pCKeyEntry[16];                // Pointer to the Alias CKey entry
+    DWORD KeySize;
+ 
 
     DWORD Parent;                                   // The index of a parent directory. If CASC_INVALID_INDEX, then this is the root item
     DWORD NameIndex;                                // Index of the node name. If CASC_INVALID_INDEX, then this node has no name

--- a/src/common/RootHandler.h
+++ b/src/common/RootHandler.h
@@ -86,6 +86,14 @@ struct TRootHandler
         return false;
     }
 
+    // Returns advanced info from the root file entry.
+    // szFileName - Pointer to the file name
+    // pFileInfo - Pointer to CASC_FILE_FULL_INFO structure
+    virtual bool GetInfo(const char* szFileName, struct _CASC_FILE_FULL_INFO* /* pFileInfo */)
+    {
+        return false;
+    }
+
     // Copies all items from the given root handler to the new one
     virtual size_t Copy(TRootHandler * /* pRoot */)
     {
@@ -124,6 +132,7 @@ struct TFileTreeRoot : public TRootHandler
     PCASC_CKEY_ENTRY GetFile(size_t nFileIndex, char * /* szFileName */, size_t /* ccFileName */);
     PCASC_CKEY_ENTRY Search(struct TCascSearch * pSearch, struct _CASC_FIND_DATA * pFindData);
     bool GetInfo(PCASC_CKEY_ENTRY pCKeyEntry, struct _CASC_FILE_FULL_INFO * pFileInfo);
+    bool GetInfo(const char* szFileName, struct _CASC_FILE_FULL_INFO* /* pFileInfo */) override;
     size_t Copy(TRootHandler * pRoot);
     size_t GetMaxFileIndex();
 


### PR DESCRIPTION
Enhanced file caching and handling in CASC library

- **Modified CascCommon.h**: 
  - Added `CascCacheWholeFile` strategy in `CSTRTG` enum.
  
- **Updated CascLib.h**: 
  - Defined `CASC_CACHE_WHOLE_FILE` flag.
  - Declared new functions: `CascSetCacheStrategy` and `CascGetFileId`.
  
- **Implemented in CascOpenFile.cpp**:
  - Added `CascSetCacheStrategy` function to set cache strategy.
  - Added `CascGetFileId` function to retrieve file ID by name.
  
- **Enhanced ReadFile performance in CascReadFile.cpp**:
  - Implemented `ReadFile_WholeCached` function for whole file caching.
  - Optimized decoded buffer handling.
  - Fixed rare invalid read issue.
  
- **Improved CKeyEntry handling in FileTree.cpp and FileTree.h**:
  - Supported multiple keys in file nodes.
  - Enhanced insertion and retrieval methods for file nodes.
  
- **Improved file retrieval in RootHandler.cpp**:
  - Enhanced methods for getting files by name and ID.
  - Added new `GetInfo` method to retrieve file info by name.
  
- **Adjusted related struct and enum definitions**:
  - Updated `CASC_FILE_NODE` struct to support multiple keys.
  - Enhanced various methods to accommodate new caching strategy and file handling improvements.