### PR TITLE
Support D2R Steam static CASC storage

### DIFF
--- a/src/CascCommon.h
+++ b/src/CascCommon.h
@@ -77,6 +77,7 @@ typedef enum _CBLD_TYPE
     CascBuildNone = 0,                              // No build type found
     CascBuildDb,                                    // .build.db (older storages)
     CascBuildInfo,                                  // .build.info
+    CascBuildConfig,                                // data\.build.config
     CascVersions                                    // versions (cached or online)
 } CBLD_TYPE, *PCBLD_TYPE;
 

--- a/src/CascFiles.cpp
+++ b/src/CascFiles.cpp
@@ -49,6 +49,7 @@ static const TBuildFileInfo BuildTypes[] =
 {
     {_T(".build.info"), 11, CascBuildInfo},         // Since HOTS build 30027, the game uses .build.info file for storage info
     {_T(".build.db"),   9,  CascBuildDb},           // Older CASC storages
+    {_T("data") _T(PATH_SEP_STRING) _T(".build.config"), 18, CascBuildConfig}, // Static CASC storage
     {_T("versions"),    8,  CascVersions},          // Online/cached CASC storages
 };
 
@@ -378,6 +379,14 @@ static DWORD LoadCKeyEntry(TCascStorage * hs, const char * szVariableName, const
     if(StringEndsWith(szVariableName, nLength, "-config", 7))
         return ERROR_SUCCESS;
 
+    // Static VFS manifests can be stored as raw ZLIB streams
+    if(hs->BuildFileType == CascBuildConfig && StringEndsWith(szVariableName, nLength, "-espec", 6))
+    {
+        if((szDataEnd - szDataPtr) == 1 && szDataPtr[0] == 'z')
+            pCKeyEntry->Flags |= CASC_CE_ZLIB_DATA;
+        return ERROR_SUCCESS;
+    }
+
     // If the variable ends at "-size", it means we need to capture the size
     if(StringEndsWith(szVariableName, nLength, "-size", 5))
     {
@@ -419,6 +428,13 @@ static DWORD LoadCKeyEntry(TCascStorage * hs, const char * szVariableName, const
                 if(szDataPtr == NULL)
                     return ERROR_BAD_FORMAT;
                 pCKeyEntry->Flags |= CASC_CE_HAS_EKEY;
+
+                // Static storages encode the data file and offset in the last 7 bytes
+                if(hs->BuildFileType == CascBuildConfig)
+                {
+                    pCKeyEntry->StorageOffset = ConvertBytesToInteger_7(pCKeyEntry->EKey + CASC_EKEY_SIZE);
+                    pCKeyEntry->Flags |= CASC_CE_FILE_IS_LOCAL;
+                }
 
                 // Increment the number of EKey entries loaded from text build file
                 hs->EKeyEntries++;
@@ -911,8 +927,26 @@ static DWORD ParseFile_CdnBuild(TCascStorage * hs, void * pvListFile)
     }
 
     // Both CKey and EKey of ENCODING file is required
-    if((hs->EncodingCKey.Flags & (CASC_CE_HAS_CKEY | CASC_CE_HAS_EKEY)) != (CASC_CE_HAS_CKEY | CASC_CE_HAS_EKEY))
+    if(hs->BuildFileType != CascBuildConfig &&
+       (hs->EncodingCKey.Flags & (CASC_CE_HAS_CKEY | CASC_CE_HAS_EKEY)) != (CASC_CE_HAS_CKEY | CASC_CE_HAS_EKEY))
         dwErrCode = ERROR_BAD_FORMAT;
+    if(hs->BuildFileType == CascBuildConfig &&
+       (hs->VfsRoot.Flags & (CASC_CE_HAS_CKEY | CASC_CE_HAS_EKEY)) != (CASC_CE_HAS_CKEY | CASC_CE_HAS_EKEY))
+        dwErrCode = ERROR_BAD_FORMAT;
+    return dwErrCode;
+}
+
+static DWORD LoadBuildConfigFile(TCascStorage * hs)
+{
+    void * pvListFile;
+    DWORD dwErrCode = ERROR_FILE_NOT_FOUND;
+
+    pvListFile = ListFile_OpenExternal(hs->szMainFile);
+    if(pvListFile != NULL)
+    {
+        dwErrCode = ParseFile_CdnBuild(hs, pvListFile);
+        CASC_FREE(pvListFile);
+    }
     return dwErrCode;
 }
 
@@ -1518,6 +1552,9 @@ DWORD CheckCascBuildFileExact(CASC_BUILD_FILE & BuildFile, LPCTSTR szLocalPath)
     // Check every type of the build file
     for(size_t i = 0; i < _countof(BuildTypes); i++)
     {
+        if(nLength < BuildTypes[i].nLength)
+            continue;
+
         // We support any file name with the appropriate ending,
         // for example wow-19342.build.info or wow-47186.versions
         szFileType = szLocalPath + nLength - BuildTypes[i].nLength;
@@ -1698,6 +1735,10 @@ DWORD LoadMainFile(TCascStorage * hs)
 
         case CascBuildInfo:     // Current storages have "build.db"
             dwErrCode = LoadCsvFile(hs, hs->szMainFile, ParseFile_BuildInfo, true);
+            break;
+
+        case CascBuildConfig:   // Static storages have "data\.build.config"
+            dwErrCode = LoadBuildConfigFile(hs);
             break;
 
         case CascVersions:      // Online storages have "versions+cdns"

--- a/src/CascOpenStorage.cpp
+++ b/src/CascOpenStorage.cpp
@@ -368,6 +368,7 @@ static size_t GetEstimatedNumberOfFiles(TCascStorage * hs)
 static DWORD InitCKeyArray(TCascStorage * hs)
 {
     size_t nNumberOfFiles = GetEstimatedNumberOfFiles(hs);
+    size_t EKeyLength = (hs->BuildFileType == CascBuildConfig) ? MD5_HASH_SIZE : CASC_EKEY_SIZE;
     DWORD dwErrCode;
 
     //
@@ -384,9 +385,9 @@ static DWORD InitCKeyArray(TCascStorage * hs)
     if(dwErrCode != ERROR_SUCCESS)
         return dwErrCode;
 
-    // Create the map CKey -> CASC_CKEY_ENTRY. Note that TVFS root references files
-    // using 9-byte EKey, so cut the search EKey length to 9 bytes
-    dwErrCode = hs->EKeyMap.Create(nNumberOfFiles, CASC_EKEY_SIZE, FIELD_OFFSET(CASC_CKEY_ENTRY, EKey));
+    // Create the map EKey -> CASC_CKEY_ENTRY. Note that most TVFS roots reference files
+    // using 9-byte EKey, while static storages use the full 16-byte EKey
+    dwErrCode = hs->EKeyMap.Create(nNumberOfFiles, EKeyLength, FIELD_OFFSET(CASC_CKEY_ENTRY, EKey));
     if(dwErrCode != ERROR_SUCCESS)
         return dwErrCode;
 
@@ -1191,10 +1192,21 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs, L
 
     // Construct the root path from the name of the build file
     CASC_PATH<TCHAR> RootPath(szMainFile, NULL);
-    hs->szRootPath = RootPath.New(true);
+    if(BuildFileType == CascBuildConfig)
+    {
+        hs->szDataPath = RootPath.New(true);
+        hs->szRootPath = RootPath.New(true);
+        hs->EKeyLength = MD5_HASH_SIZE;
+        hs->FileOffsetBits = 40;
+    }
+    else
+    {
+        hs->szRootPath = RootPath.New(true);
+    }
 
     // If either of the root path or build file is known, it's an error
-    if(hs->szRootPath == NULL || hs->szMainFile == NULL)
+    if(hs->szRootPath == NULL || hs->szMainFile == NULL ||
+       (BuildFileType == CascBuildConfig && hs->szDataPath == NULL))
     {
         dwErrCode = ERROR_NOT_ENOUGH_MEMORY;
     }
@@ -1203,14 +1215,14 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs, L
     if(dwErrCode == ERROR_SUCCESS)
     {
         // For local (game) storages, we need the data and indices subdirectory
-        if(hs->dwFeatures & CASC_FEATURE_DATA_ARCHIVES)
+        if((hs->dwFeatures & CASC_FEATURE_DATA_ARCHIVES) && BuildFileType != CascBuildConfig)
         {
             if(CheckArchiveFilesDirectories(hs) != ERROR_SUCCESS)
                 hs->dwFeatures &= ~CASC_FEATURE_DATA_ARCHIVES;
         }
 
         // For data files storage, we need that folder
-        if(hs->dwFeatures & CASC_FEATURE_DATA_FILES)
+        if((hs->dwFeatures & CASC_FEATURE_DATA_FILES) && BuildFileType != CascBuildConfig)
         {
             if(CheckDataFilesDirectory(hs) != ERROR_SUCCESS)
                 hs->dwFeatures &= ~CASC_FEATURE_DATA_FILES;
@@ -1234,7 +1246,7 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs, L
     }
 
     // Proceed with loading the CDN build file
-    if(dwErrCode == ERROR_SUCCESS)
+    if(dwErrCode == ERROR_SUCCESS && BuildFileType != CascBuildConfig)
     {
         dwErrCode = LoadCdnBuildFile(hs);
     }
@@ -1258,20 +1270,26 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs, L
         dwErrCode = InitCKeyArray(hs);
     }
 
+    // Static storages have no ENCODING manifest, so insert BUILD entries directly
+    if(dwErrCode == ERROR_SUCCESS && BuildFileType == CascBuildConfig)
+    {
+        dwErrCode = CopyBuildFileItemsToCKeyArray(hs);
+    }
+
     // Pre-load the local index files
-    if(dwErrCode == ERROR_SUCCESS)
+    if(dwErrCode == ERROR_SUCCESS && BuildFileType != CascBuildConfig)
     {
         dwErrCode = LoadIndexFiles(hs);
     }
 
     // Load the ENCODING manifest
-    if(dwErrCode == ERROR_SUCCESS)
+    if(dwErrCode == ERROR_SUCCESS && BuildFileType != CascBuildConfig)
     {
         dwErrCode = LoadEncodingManifest(hs);
     }
 
     // We need to load the DOWNLOAD manifest
-    if(dwErrCode == ERROR_SUCCESS)
+    if(dwErrCode == ERROR_SUCCESS && BuildFileType != CascBuildConfig)
     {
         dwErrCode = LoadDownloadManifest(hs);
     }
@@ -1290,10 +1308,14 @@ static DWORD LoadCascStorage(TCascStorage * hs, PCASC_OPEN_STORAGE_ARGS pArgs, L
 
         // If we fail to load the ROOT file, we take the file names from the INSTALL manifest
         // Beware on low memory condition - in that case, we cannot guarantee a consistent state of the root file
-        if(dwErrCode != ERROR_SUCCESS && dwErrCode != ERROR_NOT_ENOUGH_MEMORY)
+        if(dwErrCode != ERROR_SUCCESS && dwErrCode != ERROR_NOT_ENOUGH_MEMORY && BuildFileType != CascBuildConfig)
         {
             dwErrCode = LoadInstallManifest(hs);
         }
+
+        // All entries in a static storage describe local data files
+        if(dwErrCode == ERROR_SUCCESS && BuildFileType == CascBuildConfig)
+            hs->LocalFiles = hs->CKeyArray.ItemCount();
     }
 
     // Insert entries for files with well-known names. Their CKeys are in the BUILD file

--- a/src/CascReadFile.cpp
+++ b/src/CascReadFile.cpp
@@ -25,6 +25,26 @@ static DWORD GetStreamEncodedSize(TFileStream * pStream)
     return (DWORD)(FileSize);
 }
 
+static DWORD OpenStaticDataStream(TCascFile * hf, PCASC_FILE_SPAN pFileSpan)
+{
+    TCascStorage * hs = hf->hs;
+    TFileStream * pStream;
+    TCHAR szPlainName[0x80];
+    DWORD dwArchiveIndex = pFileSpan->ArchiveIndex;
+
+    // Static storages use files named "GG-PPPPPPPP.data"
+    CascStrPrintf(szPlainName, _countof(szPlainName), _T("%02u-%08x.data"), (dwArchiveIndex >> 8), (dwArchiveIndex & 0xFF));
+
+    CASC_PATH<TCHAR> DataFile(hs->szDataPath, szPlainName, NULL);
+    pStream = FileStream_OpenFile(DataFile, STREAM_FLAG_READ_ONLY | STREAM_FLAG_WRITE_SHARE | STREAM_PROVIDER_FLAT | STREAM_FLAG_FILL_MISSING | BASE_PROVIDER_FILE);
+    if((pFileSpan->pStream = pStream) != NULL)
+    {
+        hf->bCloseFileStream = true;
+        return ERROR_SUCCESS;
+    }
+    return ERROR_FILE_NOT_FOUND;
+}
+
 static DWORD OpenDataStream(TCascFile * hf, PCASC_FILE_SPAN pFileSpan, PCASC_CKEY_ENTRY pCKeyEntry, bool bAllowDownloading)
 {
     TCascStorage * hs = hf->hs;
@@ -37,6 +57,9 @@ static DWORD OpenDataStream(TCascFile * hf, PCASC_FILE_SPAN pFileSpan, PCASC_CKE
     if(pCKeyEntry->Flags & CASC_CE_FILE_IS_LOCAL)
     {
         DWORD dwArchiveIndex = pFileSpan->ArchiveIndex;
+
+        if(hs->BuildFileType == CascBuildConfig)
+            return OpenStaticDataStream(hf, pFileSpan);
 
         // Lock the storage to make the operation thread-safe
         CascLock(hs->StorageLock);
@@ -383,6 +406,34 @@ static DWORD LoadSpanFramesForPlainFile(PCASC_FILE_SPAN pFileSpan, PCASC_CKEY_EN
     return ERROR_NOT_ENOUGH_MEMORY;
 }
 
+static DWORD LoadSpanFramesForZlibFile(PCASC_FILE_SPAN pFileSpan, PCASC_CKEY_ENTRY pCKeyEntry)
+{
+    PCASC_FILE_FRAME pFrames;
+
+    // Allocate single "dummy" frame
+    pFrames = CASC_ALLOC<CASC_FILE_FRAME>(1);
+    if(pFrames != NULL)
+    {
+        // Setup the size
+        pFileSpan->EndOffset = pFileSpan->StartOffset + pCKeyEntry->ContentSize;
+
+        // Fill the single frame
+        memset(&pFrames->FrameHash, 0, sizeof(CONTENT_KEY));
+        pFrames->StartOffset = pFileSpan->StartOffset;
+        pFrames->EndOffset = pFrames->StartOffset + pCKeyEntry->ContentSize;
+        pFrames->DataFileOffset = pFileSpan->ArchiveOffs;
+        pFrames->EncodedSize = pCKeyEntry->EncodedSize;
+        pFrames->ContentSize = pCKeyEntry->ContentSize;
+
+        // Save the number of file frames
+        pFileSpan->FrameCount = 1;
+        pFileSpan->pFrames = pFrames;
+        return ERROR_SUCCESS;
+    }
+
+    return ERROR_NOT_ENOUGH_MEMORY;
+}
+
 static DWORD LoadEncodedHeaderAndSpanFrames(PCASC_FILE_SPAN pFileSpan, PCASC_CKEY_ENTRY pCKeyEntry)
 {
     LPBYTE pbEncodedBuffer;
@@ -392,6 +443,10 @@ static DWORD LoadEncodedHeaderAndSpanFrames(PCASC_FILE_SPAN pFileSpan, PCASC_CKE
     // Should only be called when the file frames are NOT loaded
     assert(pFileSpan->pFrames == NULL);
     assert(pFileSpan->FrameCount == 0);
+
+    // Static VFS manifests are raw ZLIB streams without a BLTE header
+    if(pCKeyEntry->Flags & CASC_CE_ZLIB_DATA)
+        return LoadSpanFramesForZlibFile(pFileSpan, pCKeyEntry);
 
     // Allocate the initial buffer for the encoded headers
     pbEncodedBuffer = CASC_ALLOC<BYTE>(MAX_ENCODED_HEADER);
@@ -567,6 +622,16 @@ static DWORD DecodeFileFrame(
     //    fwrite(pbEncoded, 1, pFrame->EncodedSize, fp);
     //    fclose(fp);
     //}
+
+    // If this is a raw ZLIB stream, decompress the entire frame
+    if(pCKeyEntry->Flags & CASC_CE_ZLIB_DATA)
+    {
+        cbDecodedExpected = cbDecoded;
+        dwErrCode = CascDecompress(pbDecoded, &cbDecoded, pbEncoded, cbEncoded);
+        if(cbDecoded < cbDecodedExpected)
+            memset(pbDecoded + cbDecoded, 0, (cbDecodedExpected - cbDecoded));
+        return dwErrCode;
+    }
 
     // If this is a file span with plain data, just copy the data
     if(pCKeyEntry->Flags & CASC_CE_PLAIN_DATA)

--- a/src/CascRootFile_TVFS.cpp
+++ b/src/CascRootFile_TVFS.cpp
@@ -183,7 +183,9 @@ struct TRootHandler_TVFS : public TFileTreeRoot
 
         // Capture the other four integers 
         pbDataPtr = CaptureByteArray(pbDataPtr, pbDataEnd, 4, &DirHeader.FormatVersion);
-        if(pbDataPtr == NULL || DirHeader.FormatVersion != 1 || DirHeader.EKeySize != 9 || DirHeader.PatchKeySize != 9 || DirHeader.HeaderSize < 8)
+        if(pbDataPtr == NULL || DirHeader.FormatVersion != 1 ||
+           (DirHeader.EKeySize != CASC_EKEY_SIZE && DirHeader.EKeySize != MD5_HASH_SIZE) ||
+           DirHeader.PatchKeySize != DirHeader.EKeySize || DirHeader.HeaderSize < 8)
             return ERROR_BAD_FORMAT;
 
         // Capture the rest
@@ -246,7 +248,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         return (1 <= SpanCount && SpanCount <= 224) ? pbVfsFileEntry : NULL;
     }
 
-    LPBYTE CaptureVfsSpanEntries(TVFS_DIRECTORY_HEADER & DirHeader, LPBYTE pbVfsSpanEntry, PCASC_CKEY_ENTRY PtrSpanEntry, size_t SpanCount)
+    LPBYTE CaptureVfsSpanEntries(TCascStorage * hs, TVFS_DIRECTORY_HEADER & DirHeader, LPBYTE pbVfsSpanEntry, PCASC_CKEY_ENTRY PtrSpanEntry, size_t SpanCount)
     {
         LPBYTE pbCftFileTable;
         LPBYTE pbCftFileEntry;
@@ -263,6 +265,9 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         for(size_t i = 0; i < SpanCount; i++)
         {
             DWORD dwCftOffset = ConvertBytesToInteger_X(pbVfsSpanEntry + sizeof(DWORD) + sizeof(DWORD), DirHeader.CftOffsSize);
+
+            if(hs->BuildFileType == CascBuildConfig)
+                PtrSpanEntry->Init();
 
             //
             // Structure of the span entry:
@@ -283,6 +288,14 @@ struct TRootHandler_TVFS : public TFileTreeRoot
             // Copy the EKey and content size
             CaptureEncodedKey(PtrSpanEntry->EKey, pbCftFileEntry, DirHeader.EKeySize);
             PtrSpanEntry->ContentSize  = ConvertBytesToInteger_4(pbVfsSpanEntry + sizeof(DWORD));
+
+            // Static storages keep the data location in the full EKey
+            if(hs->BuildFileType == CascBuildConfig)
+            {
+                PtrSpanEntry->StorageOffset = ConvertBytesToInteger_7(PtrSpanEntry->EKey + CASC_EKEY_SIZE);
+                PtrSpanEntry->EncodedSize = ConvertBytesToInteger_4(pbCftFileEntry + DirHeader.EKeySize);
+                PtrSpanEntry->Flags = CASC_CE_HAS_EKEY | CASC_CE_FILE_IS_LOCAL;
+            }
 
             // Move to the next entry
             pbVfsSpanEntry += ItemSize;
@@ -422,7 +435,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         return dwErrCode;
     }
 
-    PCASC_CKEY_ENTRY InsertUnknownCKeyEntry(TCascStorage * hs, LPBYTE pbEKey, size_t cbEKey, DWORD ContentSize)
+    PCASC_CKEY_ENTRY InsertUnknownCKeyEntry(TCascStorage * hs, CASC_CKEY_ENTRY & SpanEntry, size_t cbEKey)
     {
         PCASC_CKEY_ENTRY pCKeyEntry;
 
@@ -431,15 +444,18 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         if(pCKeyEntry != NULL)
         {
             memset(pCKeyEntry, 0, sizeof(CASC_CKEY_ENTRY));
-            memcpy(pCKeyEntry->EKey, pbEKey, cbEKey);
-            pCKeyEntry->StorageOffset = CASC_INVALID_OFFS64;
-            pCKeyEntry->ContentSize = ContentSize;
-            pCKeyEntry->EncodedSize = CASC_INVALID_SIZE;
-            pCKeyEntry->Flags = CASC_CE_HAS_EKEY | CASC_CE_HAS_EKEY_PARTIAL;
+            memcpy(pCKeyEntry->EKey, SpanEntry.EKey, cbEKey);
+            pCKeyEntry->StorageOffset = SpanEntry.StorageOffset;
+            pCKeyEntry->ContentSize = SpanEntry.ContentSize;
+            pCKeyEntry->EncodedSize = SpanEntry.EncodedSize;
+            pCKeyEntry->Flags = SpanEntry.Flags | CASC_CE_HAS_EKEY;
+            if(cbEKey != MD5_HASH_SIZE)
+                pCKeyEntry->Flags |= CASC_CE_HAS_EKEY_PARTIAL;
             pCKeyEntry->SpanCount = 1;
 
             // Copy the information from index files to the CKey entry
-            CopyEKeyEntry(hs, pCKeyEntry);
+            if(hs->BuildFileType != CascBuildConfig)
+                CopyEKeyEntry(hs, pCKeyEntry);
 
             // Insert the item into EKey map
             hs->EKeyMap.InsertObject(pCKeyEntry, pCKeyEntry->EKey);
@@ -519,7 +535,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
                         CASC_CKEY_ENTRY SpanEntry;
 
                         // Capture the single span entry
-                        pbVfsSpanEntry = CaptureVfsSpanEntries(DirHeader, pbVfsSpanEntry, &SpanEntry, 1);
+                        pbVfsSpanEntry = CaptureVfsSpanEntries(hs, DirHeader, pbVfsSpanEntry, &SpanEntry, 1);
                         if(pbVfsSpanEntry == NULL)
                             return ERROR_FILE_CORRUPT;
 
@@ -529,7 +545,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
                         {
                             // Some files are in the ROOT manifest even if they are not in ENCODING and DOWNLOAD.
                             // Example: "2018 - New CASC\00001", file "DivideAndConquer.w3m:war3mapMap.blp"
-                            pCKeyEntry = InsertUnknownCKeyEntry(hs, SpanEntry.EKey, DirHeader.EKeySize, SpanEntry.ContentSize);
+                            pCKeyEntry = InsertUnknownCKeyEntry(hs, SpanEntry, DirHeader.EKeySize);
                             if(pCKeyEntry == NULL)
                             {
                                 return ERROR_NOT_ENOUGH_MEMORY;
@@ -602,7 +618,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
                             return ERROR_NOT_ENOUGH_MEMORY;
 
                         // Capture all span entries
-                        pbVfsSpanEntry = CaptureVfsSpanEntries(DirHeader, pbVfsSpanEntry, pSpanEntries, dwSpanCount);
+                        pbVfsSpanEntry = CaptureVfsSpanEntries(hs, DirHeader, pbVfsSpanEntry, pSpanEntries, dwSpanCount);
                         if(pbVfsSpanEntry == NULL)
                             return ERROR_FILE_CORRUPT;
 
@@ -615,8 +631,17 @@ struct TRootHandler_TVFS : public TFileTreeRoot
                             pCKeyEntry = FindCKeyEntry_EKey(hs, pSpanEntries[dwSpanIndex].EKey);
                             if(pCKeyEntry == NULL)
                             {
-                                bFilePresent = false;
-                                break;
+                                if(hs->BuildFileType == CascBuildConfig)
+                                {
+                                    pCKeyEntry = InsertUnknownCKeyEntry(hs, *pSpanEntry, DirHeader.EKeySize);
+                                    if(pCKeyEntry == NULL)
+                                        return ERROR_NOT_ENOUGH_MEMORY;
+                                }
+                                else
+                                {
+                                    bFilePresent = false;
+                                    break;
+                                }
                             }
 
                             // Supply the content size

--- a/src/CascRootFile_TVFS.cpp
+++ b/src/CascRootFile_TVFS.cpp
@@ -119,6 +119,112 @@ typedef struct _TVFS_WOW_ENTRY
     BYTE  ContentKey[MD5_HASH_SIZE];
 } TVFS_WOW_ENTRY, *PTVFS_WOW_ENTRY;
 
+typedef struct _TVFS_D2R_STEAM_PATH_FIXUP
+{
+    const char * szPath;
+    DWORD SeparatorCount;
+} TVFS_D2R_STEAM_PATH_FIXUP, *PTVFS_D2R_STEAM_PATH_FIXUP;
+
+//-----------------------------------------------------------------------------
+// Local variables
+
+// Content key of the D2R 3.2.0.1 Steam VFS manifest
+static const BYTE D2RSteamVfsCKey[MD5_HASH_SIZE] =
+{
+    0x82, 0xDD, 0x01, 0x5C, 0x88, 0x59, 0x31, 0x4B,
+    0x13, 0xAC, 0xE5, 0x83, 0xB8, 0xD1, 0xDF, 0x64
+};
+
+// The Steam manifest omits empty-name directory nodes present in the Battle.net manifest.
+// Each entry gives the number of leading path-table branches that belonged to the omitted node.
+static const TVFS_D2R_STEAM_PATH_FIXUP D2RSteamPathFixups[] =
+{
+    {"data/global/sfx/monster/baal", 9},
+    {"data/global/sfx/monster/diablo", 6},
+    {"data/global/sfx/monster/fallen", 6},
+    {"data/global/sfx/monster/guard", 2},
+    {"data/global/sfx/monster/hawk", 4},
+    {"data/global/sfx/monster/pygmy", 6},
+    {"data/global/sfx/monster/sandmaggot", 7},
+    {"data/global/sfx/monster/tentacle", 3},
+    {"data/hd/env/model/act1/barracks/act1_barracks_props", 3},
+    {"data/hd/env/model/act1/barracks/act1_barracks_walls", 4},
+    {"data/hd/env/model/act1/catacomb/act1_catacomb_walls", 7},
+    {"data/hd/env/model/act1/court/act1_courtyard_walls", 5},
+    {"data/hd/env/model/act1/outdoors/act1_outdoors_stonewalls", 2},
+    {"data/hd/env/model/act2/palace/cell/act2_palace_cell_walls", 6},
+    {"data/hd/env/model/act2/palace/harem/act2_palace_harem_walls", 8},
+    {"data/hd/env/model/act2/tomb/act2_tomb_pillars", 3},
+    {"data/hd/env/model/act2/tomb/act2_tomb_walls", 5},
+    {"data/hd/env/model/act2/town/act2_town_shops", 2},
+    {"data/hd/env/model/act4/diab/act4_diab_cathedral", 6},
+    {"data/hd/env/model/act4/lava/act4_lava_fortress", 4},
+    {"data/hd/env/model/act4/mesa/act4_mesa_ruin_walls", 2},
+    {"data/hd/env/model/expansion/icecave/expansion_icecave_ledges", 2},
+    {"data/hd/env/model/expansion/icecave/expansion_icecave_walls", 2},
+    {"data/hd/env/model/expansion/siege/expansion_siege_cliffs", 3},
+    {"data/hd/env/model/expansion/siege/expansion_siege_forts", 3},
+    {"data/hd/env/model/expansion/siege/expansion_siege_hills", 2},
+    {"data/hd/env/model/expansion/town/expansion_town_cloth/awning_cloth01", 2},
+    {"data/hd/env/model/expansion/town/expansion_town_cloth/awning_cloth02", 2},
+    {"data/hd/env/model/expansion/town/expansion_town_details", 8},
+    {"data/hd/env/model/expansion/town/expansion_town_structures/expansion_town_structure09", 2},
+    {"data/hd/env/model/expansion/wildtemple/expansion_wildtemple_walls", 6},
+    {"data/hd/env/model/global/prop/act1/outdoors/act1_outdoors_rocks", 3},
+    {"data/hd/env/model/global/prop/act2/tomb/act2_tomb_stone_tiles", 2},
+    {"data/hd/env/model/global/prop/act3/jungle", 2},
+    {"data/hd/env/model/global/prop/expansion/siege/expansion_siege_debris", 3},
+    {"data/hd/env/texture/expansion/icecave/icecave_walls", 2},
+    {"data/hd/env/texture/expansion/town/town_structures/structure09", 2},
+    {"data/hd/global/sfx/monster/baal", 10},
+    {"data/hd/global/sfx/monster/diablo", 6},
+    {"data/hd/global/sfx/monster/fallen", 6},
+    {"data/hd/items/misc/gold/gold", 2},
+    {"data/hd/overlays/object", 2},
+    {"data/hd/vfx/meshes/character/enemy/nihlathak", 4},
+    {"data/hd/vfx/meshes/overlay", 2},
+    {"data/hd/vfx/particles/missiles/ice_icefrozenorb", 2},
+    {"data/local/font/latin", 3},
+    {"data/local/lng/strings", 13}
+};
+
+//-----------------------------------------------------------------------------
+// Local functions
+
+static bool IsD2RSteamVfs(TCascStorage * hs)
+{
+    PCASC_CKEY_ENTRY pCKeyEntry;
+
+    if(hs->BuildFileType == CascBuildConfig)
+    {
+        size_t ItemCount = hs->VfsRootList.ItemCount();
+
+        for(size_t i = 0; i < ItemCount; i++)
+        {
+            pCKeyEntry = (PCASC_CKEY_ENTRY)hs->VfsRootList.ItemAt(i);
+
+            if(pCKeyEntry != NULL && !memcmp(pCKeyEntry->CKey, D2RSteamVfsCKey, MD5_HASH_SIZE))
+                return true;
+        }
+    }
+    return false;
+}
+
+static DWORD GetD2RSteamSeparatorCount(const CASC_PATH<char> & PathBuffer)
+{
+    const char * szPath = strrchr(PathBuffer, ':');
+
+    // Ignore the virtual file system prefix (for example "data:")
+    szPath = (szPath != NULL) ? (szPath + 1) : PathBuffer;
+
+    for(size_t i = 0; i < _countof(D2RSteamPathFixups); i++)
+    {
+        if(!strcmp(szPath, D2RSteamPathFixups[i].szPath))
+            return D2RSteamPathFixups[i].SeparatorCount;
+    }
+    return 0;
+}
+
 //-----------------------------------------------------------------------------
 // Handler definition for TVFS root file
 
@@ -131,6 +237,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
     {
         // TVFS supports file names, but DOESN'T support CKeys.
         dwFeatures |= CASC_FEATURE_FILE_NAMES;
+        bD2RSteamVfs = false;
     }
 
     // Returns size of "container file table offset" field in the VFS.
@@ -484,8 +591,11 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         PCASC_CKEY_ENTRY pCKeyEntry;
         LPBYTE pbVfsSpanEntry;
         size_t  nSavePos = PathBuffer.Save();
+        DWORD dwSeparatorCount = bD2RSteamVfs ? GetD2RSteamSeparatorCount(PathBuffer) : 0;
+        DWORD dwPathIndex = 0;
         DWORD dwSpanCount;
         DWORD dwErrCode;
+        bool bPathStart = true;
 
         // Sanity check
         assert(SpanArray.IsInitialized());
@@ -497,6 +607,10 @@ struct TRootHandler_TVFS : public TFileTreeRoot
             pbPathTablePtr = CapturePathEntry(PathEntry, pbPathTablePtr, pbPathTableEnd);
             if(pbPathTablePtr == NULL)
                 return ERROR_BAD_FORMAT;
+
+            // Restore a directory separator omitted by the D2R Steam manifest
+            if(bPathStart && dwPathIndex < dwSeparatorCount)
+                PathEntry.NodeFlags |= TVFS_PTE_PATH_SEPARATOR_PRE;
 
             // Append the node name to the total path. Also add backslash, if it's a folder
             PathBuffer_AppendNode(PathBuffer, PathEntry);
@@ -683,7 +797,11 @@ struct TRootHandler_TVFS : public TFileTreeRoot
 
                 // Reset the position of the path buffer
                 PathBuffer.Restore(nSavePos);
+                dwPathIndex++;
+                bPathStart = true;
             }
+            else
+                bPathStart = false;
         }
 
         // Return the total number of entries
@@ -732,6 +850,9 @@ struct TRootHandler_TVFS : public TFileTreeRoot
     {
         CASC_PATH<char> PathBuffer;
         DWORD dwErrCode;
+
+        // Enable manifest-specific path reconstruction
+        bD2RSteamVfs = IsD2RSteamVfs(hs);
 
         // Save the length of the key
         FileTree.SetKeyLength(RootHeader.EKeySize);
@@ -810,6 +931,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
     }
 
     CASC_ARRAY SpanArray;           // Array of CASC_SPAN_ENTRY for all multi-span files
+    bool bD2RSteamVfs;              // The D2R Steam VFS needs path separators restored
 };
 
 //-----------------------------------------------------------------------------

--- a/src/CascRootFile_TVFS.cpp
+++ b/src/CascRootFile_TVFS.cpp
@@ -119,112 +119,6 @@ typedef struct _TVFS_WOW_ENTRY
     BYTE  ContentKey[MD5_HASH_SIZE];
 } TVFS_WOW_ENTRY, *PTVFS_WOW_ENTRY;
 
-typedef struct _TVFS_D2R_STEAM_PATH_FIXUP
-{
-    const char * szPath;
-    DWORD SeparatorCount;
-} TVFS_D2R_STEAM_PATH_FIXUP, *PTVFS_D2R_STEAM_PATH_FIXUP;
-
-//-----------------------------------------------------------------------------
-// Local variables
-
-// Content key of the D2R 3.2.0.1 Steam VFS manifest
-static const BYTE D2RSteamVfsCKey[MD5_HASH_SIZE] =
-{
-    0x82, 0xDD, 0x01, 0x5C, 0x88, 0x59, 0x31, 0x4B,
-    0x13, 0xAC, 0xE5, 0x83, 0xB8, 0xD1, 0xDF, 0x64
-};
-
-// The Steam manifest omits empty-name directory nodes present in the Battle.net manifest.
-// Each entry gives the number of leading path-table branches that belonged to the omitted node.
-static const TVFS_D2R_STEAM_PATH_FIXUP D2RSteamPathFixups[] =
-{
-    {"data/global/sfx/monster/baal", 9},
-    {"data/global/sfx/monster/diablo", 6},
-    {"data/global/sfx/monster/fallen", 6},
-    {"data/global/sfx/monster/guard", 2},
-    {"data/global/sfx/monster/hawk", 4},
-    {"data/global/sfx/monster/pygmy", 6},
-    {"data/global/sfx/monster/sandmaggot", 7},
-    {"data/global/sfx/monster/tentacle", 3},
-    {"data/hd/env/model/act1/barracks/act1_barracks_props", 3},
-    {"data/hd/env/model/act1/barracks/act1_barracks_walls", 4},
-    {"data/hd/env/model/act1/catacomb/act1_catacomb_walls", 7},
-    {"data/hd/env/model/act1/court/act1_courtyard_walls", 5},
-    {"data/hd/env/model/act1/outdoors/act1_outdoors_stonewalls", 2},
-    {"data/hd/env/model/act2/palace/cell/act2_palace_cell_walls", 6},
-    {"data/hd/env/model/act2/palace/harem/act2_palace_harem_walls", 8},
-    {"data/hd/env/model/act2/tomb/act2_tomb_pillars", 3},
-    {"data/hd/env/model/act2/tomb/act2_tomb_walls", 5},
-    {"data/hd/env/model/act2/town/act2_town_shops", 2},
-    {"data/hd/env/model/act4/diab/act4_diab_cathedral", 6},
-    {"data/hd/env/model/act4/lava/act4_lava_fortress", 4},
-    {"data/hd/env/model/act4/mesa/act4_mesa_ruin_walls", 2},
-    {"data/hd/env/model/expansion/icecave/expansion_icecave_ledges", 2},
-    {"data/hd/env/model/expansion/icecave/expansion_icecave_walls", 2},
-    {"data/hd/env/model/expansion/siege/expansion_siege_cliffs", 3},
-    {"data/hd/env/model/expansion/siege/expansion_siege_forts", 3},
-    {"data/hd/env/model/expansion/siege/expansion_siege_hills", 2},
-    {"data/hd/env/model/expansion/town/expansion_town_cloth/awning_cloth01", 2},
-    {"data/hd/env/model/expansion/town/expansion_town_cloth/awning_cloth02", 2},
-    {"data/hd/env/model/expansion/town/expansion_town_details", 8},
-    {"data/hd/env/model/expansion/town/expansion_town_structures/expansion_town_structure09", 2},
-    {"data/hd/env/model/expansion/wildtemple/expansion_wildtemple_walls", 6},
-    {"data/hd/env/model/global/prop/act1/outdoors/act1_outdoors_rocks", 3},
-    {"data/hd/env/model/global/prop/act2/tomb/act2_tomb_stone_tiles", 2},
-    {"data/hd/env/model/global/prop/act3/jungle", 2},
-    {"data/hd/env/model/global/prop/expansion/siege/expansion_siege_debris", 3},
-    {"data/hd/env/texture/expansion/icecave/icecave_walls", 2},
-    {"data/hd/env/texture/expansion/town/town_structures/structure09", 2},
-    {"data/hd/global/sfx/monster/baal", 10},
-    {"data/hd/global/sfx/monster/diablo", 6},
-    {"data/hd/global/sfx/monster/fallen", 6},
-    {"data/hd/items/misc/gold/gold", 2},
-    {"data/hd/overlays/object", 2},
-    {"data/hd/vfx/meshes/character/enemy/nihlathak", 4},
-    {"data/hd/vfx/meshes/overlay", 2},
-    {"data/hd/vfx/particles/missiles/ice_icefrozenorb", 2},
-    {"data/local/font/latin", 3},
-    {"data/local/lng/strings", 13}
-};
-
-//-----------------------------------------------------------------------------
-// Local functions
-
-static bool IsD2RSteamVfs(TCascStorage * hs)
-{
-    PCASC_CKEY_ENTRY pCKeyEntry;
-
-    if(hs->BuildFileType == CascBuildConfig)
-    {
-        size_t ItemCount = hs->VfsRootList.ItemCount();
-
-        for(size_t i = 0; i < ItemCount; i++)
-        {
-            pCKeyEntry = (PCASC_CKEY_ENTRY)hs->VfsRootList.ItemAt(i);
-
-            if(pCKeyEntry != NULL && !memcmp(pCKeyEntry->CKey, D2RSteamVfsCKey, MD5_HASH_SIZE))
-                return true;
-        }
-    }
-    return false;
-}
-
-static DWORD GetD2RSteamSeparatorCount(const CASC_PATH<char> & PathBuffer)
-{
-    const char * szPath = strrchr(PathBuffer, ':');
-
-    // Ignore the virtual file system prefix (for example "data:")
-    szPath = (szPath != NULL) ? (szPath + 1) : PathBuffer;
-
-    for(size_t i = 0; i < _countof(D2RSteamPathFixups); i++)
-    {
-        if(!strcmp(szPath, D2RSteamPathFixups[i].szPath))
-            return D2RSteamPathFixups[i].SeparatorCount;
-    }
-    return 0;
-}
-
 //-----------------------------------------------------------------------------
 // Handler definition for TVFS root file
 
@@ -237,7 +131,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
     {
         // TVFS supports file names, but DOESN'T support CKeys.
         dwFeatures |= CASC_FEATURE_FILE_NAMES;
-        bD2RSteamVfs = false;
+        bParseVfsSubDirectories = true;
     }
 
     // Returns size of "container file table offset" field in the VFS.
@@ -584,6 +478,134 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         }
     }
 
+    DWORD CreateRootFileNameMap(CASC_BLOB & RootFile)
+    {
+        const char * szRootFileEnd = (const char *)RootFile.End();
+        const char * szRootFilePtr = (const char *)RootFile.pbData;
+        const char * szLineBegin;
+        const char * szLineEnd;
+        const char * szNameEnd;
+        const char * szNamePtr;
+        char * szRootNamePtr;
+        char * szLookupName;
+        size_t FileCount = 0;
+        size_t BufferSize;
+        DWORD dwErrCode;
+
+        // Count the number of file names in the text ROOT
+        for(size_t i = 0; i < RootFile.cbData; i++)
+        {
+            if(RootFile.pbData[i] == '\n')
+                FileCount++;
+        }
+        if(RootFile.cbData != 0 && RootFile.pbData[RootFile.cbData - 1] != '\n')
+            FileCount++;
+        if(FileCount == 0 || RootFile.cbData > ((SIZE_MAX - 1) / 2))
+            return ERROR_BAD_FORMAT;
+
+        // Each record contains the separator-less lookup name and the original name
+        BufferSize = RootFile.cbData * 2;
+        dwErrCode = RootFileNames.SetSize(BufferSize);
+        if(dwErrCode != ERROR_SUCCESS)
+            return dwErrCode;
+
+        dwErrCode = RootFileNameMap.Create(FileCount, 0, 0, KeyIsString);
+        if(dwErrCode != ERROR_SUCCESS)
+            return dwErrCode;
+
+        szRootNamePtr = (char *)RootFileNames.pbData;
+        while(szRootFilePtr < szRootFileEnd)
+        {
+            // Capture one line
+            while(szRootFilePtr < szRootFileEnd && (szRootFilePtr[0] == '\r' || szRootFilePtr[0] == '\n'))
+                szRootFilePtr++;
+            szLineBegin = szRootFilePtr;
+            while(szRootFilePtr < szRootFileEnd && szRootFilePtr[0] != '\r' && szRootFilePtr[0] != '\n')
+                szRootFilePtr++;
+            szLineEnd = szRootFilePtr;
+
+            // The file name is the first column in "name|md5|plugin"
+            for(szNameEnd = szLineBegin; szNameEnd < szLineEnd && szNameEnd[0] != '|'; szNameEnd++)
+                ;
+            if(szNameEnd == szLineBegin || szNameEnd == szLineEnd)
+                continue;
+
+            // Create the case-insensitive lookup name without path separators
+            szLookupName = szRootNamePtr;
+            for(szNamePtr = szLineBegin; szNamePtr < szNameEnd; szNamePtr++)
+            {
+                if(szNamePtr[0] != '/' && szNamePtr[0] != '\\')
+                    *szRootNamePtr++ = szNamePtr[0];
+            }
+            *szRootNamePtr++ = 0;
+
+            // Keep the original name immediately after the lookup name
+            memcpy(szRootNamePtr, szLineBegin, (szNameEnd - szLineBegin));
+            szRootNamePtr += (szNameEnd - szLineBegin);
+            *szRootNamePtr++ = 0;
+
+            // Ambiguous lookup names make this ROOT unsuitable for reconstruction
+            if(!RootFileNameMap.InsertString(szLookupName, false))
+            {
+                RootFileNameMap.Free();
+                RootFileNames.Free();
+                return ERROR_BAD_FORMAT;
+            }
+        }
+
+        RootFileNames.cbData = (szRootNamePtr - (char *)RootFileNames.pbData);
+        return ERROR_SUCCESS;
+    }
+
+    DWORD LoadRootFileNameMap(TCascStorage * hs)
+    {
+        PCASC_CKEY_ENTRY pCKeyEntry;
+        CASC_BLOB RootFile;
+        BYTE RootFileHash[MD5_HASH_SIZE];
+        DWORD dwErrCode;
+
+        // Static D2R storages expose their classic text ROOT as "index"
+        pCKeyEntry = GetFile(hs, "index");
+        if(pCKeyEntry == NULL || (hs->RootFile.Flags & CASC_CE_HAS_CKEY) == 0)
+            return ERROR_SUCCESS;
+
+        // Verify that this is the ROOT declared by the build configuration
+        dwErrCode = LoadInternalFileToMemory(hs, pCKeyEntry, RootFile);
+        if(dwErrCode != ERROR_SUCCESS)
+            return ERROR_SUCCESS;
+        CascHash_MD5(RootFile.pbData, RootFile.cbData, RootFileHash);
+        if(memcmp(RootFileHash, hs->RootFile.CKey, MD5_HASH_SIZE))
+            return ERROR_SUCCESS;
+
+        return CreateRootFileNameMap(RootFile);
+    }
+
+    const char * GetRootFileName(const CASC_PATH<char> & PathBuffer)
+    {
+        const char * szPath = (const char *)PathBuffer;
+        const char * szLookupName;
+        const char * szRootFileName;
+        CASC_PATH<char> LookupName;
+
+        if(RootFileNameMap.IsInitialized())
+        {
+            // The Steam TVFS may omit path separators. The text ROOT retains them.
+            while(szPath[0] != 0)
+            {
+                if(szPath[0] != '/' && szPath[0] != '\\')
+                    LookupName.AppendChar(szPath[0]);
+                szPath++;
+            }
+
+            szLookupName = (const char *)LookupName;
+            szRootFileName = RootFileNameMap.FindString(szLookupName, szLookupName + LookupName.Length());
+            if(szRootFileName != NULL)
+                return szRootFileName + strlen(szRootFileName) + 1;
+        }
+
+        return (const char *)PathBuffer;
+    }
+
     DWORD ParsePathFileTable(TCascStorage * hs, TVFS_DIRECTORY_HEADER & DirHeader, CASC_PATH<char> & PathBuffer, LPBYTE pbPathTablePtr, LPBYTE pbPathTableEnd)
     {
         TVFS_DIRECTORY_HEADER SubHeader;
@@ -591,11 +613,8 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         PCASC_CKEY_ENTRY pCKeyEntry;
         LPBYTE pbVfsSpanEntry;
         size_t  nSavePos = PathBuffer.Save();
-        DWORD dwSeparatorCount = bD2RSteamVfs ? GetD2RSteamSeparatorCount(PathBuffer) : 0;
-        DWORD dwPathIndex = 0;
         DWORD dwSpanCount;
         DWORD dwErrCode;
-        bool bPathStart = true;
 
         // Sanity check
         assert(SpanArray.IsInitialized());
@@ -607,10 +626,6 @@ struct TRootHandler_TVFS : public TFileTreeRoot
             pbPathTablePtr = CapturePathEntry(PathEntry, pbPathTablePtr, pbPathTableEnd);
             if(pbPathTablePtr == NULL)
                 return ERROR_BAD_FORMAT;
-
-            // Restore a directory separator omitted by the D2R Steam manifest
-            if(bPathStart && dwPathIndex < dwSeparatorCount)
-                PathEntry.NodeFlags |= TVFS_PTE_PATH_SEPARATOR_PRE;
 
             // Append the node name to the total path. Also add backslash, if it's a folder
             PathBuffer_AppendNode(PathBuffer, PathEntry);
@@ -674,17 +689,20 @@ struct TRootHandler_TVFS : public TFileTreeRoot
                         // We need to check whether this is another TVFS directory file
                         if(IsVfsSubDirectory(hs, DirHeader, SubHeader, SpanEntry.EKey, SpanEntry.ContentSize) == ERROR_SUCCESS)
                         {
-                            // Add colon (':')
-                            PathBuffer.AppendChar(':');
+                            if(bParseVfsSubDirectories)
+                            {
+                                // Add colon (':')
+                                PathBuffer.AppendChar(':');
 
-                            // The file content size should already be there
-                            assert(pCKeyEntry->ContentSize == SpanEntry.ContentSize);
-                            FileTree.InsertByName(pCKeyEntry, PathBuffer);
+                                // The file content size should already be there
+                                assert(pCKeyEntry->ContentSize == SpanEntry.ContentSize);
+                                FileTree.InsertByName(pCKeyEntry, PathBuffer);
 
-                            // Parse the subdir. On error, stop the parsing
-                            dwErrCode = ParseDirectoryData(hs, SubHeader, PathBuffer);
-                            if(dwErrCode != ERROR_SUCCESS)
-                                return dwErrCode;
+                                // Parse the subdir. On error, stop the parsing
+                                dwErrCode = ParseDirectoryData(hs, SubHeader, PathBuffer);
+                                if(dwErrCode != ERROR_SUCCESS)
+                                    return dwErrCode;
+                            }
                         }
                         else
                         {
@@ -698,11 +716,12 @@ struct TRootHandler_TVFS : public TFileTreeRoot
                             switch(dwErrCode = CheckWoWGenericName(PathBuffer, WowEntry))
                             {
                                 case ERROR_SUCCESS:         // The entry was recognized and has the right format
-                                    FileTree.InsertByName(pCKeyEntry, PathBuffer, WowEntry.FileDataId, WowEntry.LocaleFlags, WowEntry.ContentFlags);
+                                    FileTree.InsertByName(pCKeyEntry, GetRootFileName(PathBuffer), WowEntry.FileDataId,
+                                                          WowEntry.LocaleFlags, WowEntry.ContentFlags);
                                     break;
 
                                 case ERROR_BAD_FORMAT:      // The entry was not recognized as TVFS WoW name
-                                    FileTree.InsertByName(pCKeyEntry, PathBuffer);
+                                    FileTree.InsertByName(pCKeyEntry, GetRootFileName(PathBuffer));
                                     break;
 
                                 default:                    // The entry has a bad format - use classic ROOT file
@@ -786,7 +805,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
                         {
                             // Insert a new file node that will contain pointer to the span entries
                             RefCount = pSpanEntries->RefCount;
-                            pFileNode = FileTree.InsertByName(pSpanEntries, PathBuffer);
+                            pFileNode = FileTree.InsertByName(pSpanEntries, GetRootFileName(PathBuffer));
                             pSpanEntries->RefCount = RefCount;
 
                             if(pFileNode == NULL)
@@ -797,11 +816,7 @@ struct TRootHandler_TVFS : public TFileTreeRoot
 
                 // Reset the position of the path buffer
                 PathBuffer.Restore(nSavePos);
-                dwPathIndex++;
-                bPathStart = true;
             }
-            else
-                bPathStart = false;
         }
 
         // Return the total number of entries
@@ -851,9 +866,6 @@ struct TRootHandler_TVFS : public TFileTreeRoot
         CASC_PATH<char> PathBuffer;
         DWORD dwErrCode;
 
-        // Enable manifest-specific path reconstruction
-        bD2RSteamVfs = IsD2RSteamVfs(hs);
-
         // Save the length of the key
         FileTree.SetKeyLength(RootHeader.EKeySize);
 
@@ -864,6 +876,22 @@ struct TRootHandler_TVFS : public TFileTreeRoot
 
         // Insert the main VFS root file as named entry
         InsertRootVfsEntry(hs, hs->VfsRoot.CKey, "vfs-root", 0);
+
+        // Static storages may contain a text ROOT next to the mounted VFS.
+        // Parse the wrapper without its subdirectories first so we can use the
+        // original file names while parsing the main VFS.
+        if(hs->BuildFileType == CascBuildConfig)
+        {
+            bParseVfsSubDirectories = false;
+            dwErrCode = ParseDirectoryData(hs, RootHeader, PathBuffer);
+            bParseVfsSubDirectories = true;
+            if(dwErrCode != ERROR_SUCCESS)
+                return dwErrCode;
+
+            dwErrCode = LoadRootFileNameMap(hs);
+            if(dwErrCode != ERROR_SUCCESS && dwErrCode != ERROR_BAD_FORMAT)
+                return dwErrCode;
+        }
 
         // Insert all VFS roots folders as files
         //for(size_t i = 0; i < hs->VfsRootList.ItemCount(); i++)
@@ -931,7 +959,9 @@ struct TRootHandler_TVFS : public TFileTreeRoot
     }
 
     CASC_ARRAY SpanArray;           // Array of CASC_SPAN_ENTRY for all multi-span files
-    bool bD2RSteamVfs;              // The D2R Steam VFS needs path separators restored
+    CASC_BLOB RootFileNames;        // Separator-less lookup names followed by original names
+    CASC_MAP RootFileNameMap;       // Map of separator-less names to RootFileNames records
+    bool bParseVfsSubDirectories;   // False while locating the text ROOT in a VFS wrapper
 };
 
 //-----------------------------------------------------------------------------

--- a/src/common/Common.h
+++ b/src/common/Common.h
@@ -72,6 +72,7 @@ typedef struct _CASC_EKEY_ENTRY
 #define CASC_CE_FILE_PATCH         0x0400           // The file is in PATCH subfolder in remote storage
 #define CASC_CE_PLAIN_DATA         0x0800           // The file data is not BLTE encoded, but in plain format
 #define CASC_CE_OPEN_CKEY_ONCE     0x1000           // Used by CascLib test program - only opens a file with given CKey once, regardless on how many file names does it have
+#define CASC_CE_ZLIB_DATA          0x2000           // The file data is a raw ZLIB stream
 
 // In-memory representation of a single entry. 
 struct CASC_CKEY_ENTRY
@@ -256,6 +257,22 @@ inline ULONGLONG ConvertBytesToInteger_5(LPBYTE ValueAsBytes)
     Value = (Value << 0x08) | ValueAsBytes[2];
     Value = (Value << 0x08) | ValueAsBytes[3];
     Value = (Value << 0x08) | ValueAsBytes[4];
+
+    return Value;
+}
+
+// Read the 56-bit big-endian offset into ULONGLONG
+inline ULONGLONG ConvertBytesToInteger_7(LPBYTE ValueAsBytes)
+{
+    ULONGLONG Value = 0;
+
+    Value = (Value << 0x08) | ValueAsBytes[0];
+    Value = (Value << 0x08) | ValueAsBytes[1];
+    Value = (Value << 0x08) | ValueAsBytes[2];
+    Value = (Value << 0x08) | ValueAsBytes[3];
+    Value = (Value << 0x08) | ValueAsBytes[4];
+    Value = (Value << 0x08) | ValueAsBytes[5];
+    Value = (Value << 0x08) | ValueAsBytes[6];
 
     return Value;
 }


### PR DESCRIPTION
## Summary

Add support for the Static Build Configuration used by the Steam version of
Diablo II: Resurrected after Patch 3.2.0.1.

Blizzard describes this patch as a restructuring of the game's underlying data:

https://us.forums.blizzard.com/en/d2r/t/patch-3201-july-14-2026/177013

Fixes #289.

## Changes

- Detect `data/.build.config` as a local CASC build file.
- Support TVFS manifests with 16-byte EKeys and patch keys.
- Decode the current `8 / 8 / 40` static key layout from the full EKey.
- Open static data files named `GG-PPPPPPPP.data`.
- Load raw ZLIB-compressed VFS manifests without a BLTE header.
- Read encoded sizes and local file locations directly from the TVFS container
  file table.
- Load static storage without local index, ENCODING, or DOWNLOAD manifests.
- Keep the existing `.build.info`, `.build.db`, and `versions` loading paths
  unchanged.